### PR TITLE
fix: restore zone state updates and add irrigation icons

### DIFF
--- a/Netro Sprinklers.indigoPlugin/Contents/Info.plist
+++ b/Netro Sprinklers.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.1.1</string>
+	<string>2026.1.2</string>
 	<key>ServerApiVersion</key>
 	<string>3.6</string>
 	<key>IwsApiVersion</key>

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -436,10 +436,7 @@ class Plugin(indigo.PluginBase):
                     (s["value"] for s in zone_states if s["key"] == "enabled"), False
                 )
 
-                if not is_enabled:
-                    zone_dev.setErrorStateOnServer('disabled')
-                else:
-                    zone_dev.setErrorStateOnServer('')
+                if is_enabled:
                     if schedule_response:
                         states.extend(
                             self.zone_handler.process_zone_schedules(
@@ -451,6 +448,23 @@ class Plugin(indigo.PluginBase):
                         states.extend(
                             self.zone_handler.process_zone_moisture(moisture_response, zone_num)
                         )
+
+                if states:
+                    zone_dev.updateStatesOnServer(states)
+
+                # Set error state and icon after state update
+                if not is_enabled:
+                    zone_dev.setErrorStateOnServer('disabled')
+                    zone_dev.updateStateImageOnServer(indigo.kStateImageSel.NoImage)
+                else:
+                    zone_dev.setErrorStateOnServer('')
+                    is_irrigating = next(
+                        (s["value"] for s in states if s["key"] == "isIrrigating"), False
+                    )
+                    if is_irrigating:
+                        zone_dev.updateStateImageOnServer(indigo.kStateImageSel.SprinklerOn)
+                    else:
+                        zone_dev.updateStateImageOnServer(indigo.kStateImageSel.HumiditySensor)
             except Exception as exc:
                 self.logger.error(f"Error updating zone device '{zone_dev.name}': {exc}")
                 self.logger.debug(f"Zone update error: \n{traceback.format_exc(10)}")


### PR DESCRIPTION
## Summary

Closes #41

Fixes two bugs introduced in #38 zone devices:

1. **Zone states not updating** — `updateStatesOnServer()` was accidentally dropped when the disabled zone logic was added. States were built but never written to devices, so `isIrrigating` and schedule data never showed on zone devices.

2. **Disabled zones losing error state** — `setErrorStateOnServer('disabled')` was called before `updateStatesOnServer`, which cleared the error display.

### Also adds
- **Irrigation icons** on zone devices: sprinkler icon when irrigating, humidity sensor when idle, no icon when disabled

## Changes

- `plugin.py` `_update_zone_devices`: restructured to update states first, then set error state and icon

## Test plan

- [x] 349 tests pass
- [x] Deployed — zone states now update correctly
- [x] Disabled zones show "disabled" error state
- [x] Active irrigation shows sprinkler icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved zone device state handling to correctly process enabled and disabled zones.
  * Enhanced error state management and device icon selection based on whether a zone is irrigating.

* **Chores**
  * Bumped plugin version to 2026.1.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->