### PR TITLE
feat: per-zone Whisperer pairing with sensor-over-forecast fallback

### DIFF
--- a/Netro Sprinklers.indigoPlugin/Contents/Info.plist
+++ b/Netro Sprinklers.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.5.1</string>
+	<string>2026.5.2</string>
 	<key>ServerApiVersion</key>
 	<string>3.6</string>
 	<key>IwsApiVersion</key>

--- a/Netro Sprinklers.indigoPlugin/Contents/Info.plist
+++ b/Netro Sprinklers.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.5.0</string>
+	<string>2026.5.1</string>
 	<key>ServerApiVersion</key>
 	<string>3.6</string>
 	<key>IwsApiVersion</key>

--- a/Netro Sprinklers.indigoPlugin/Contents/Info.plist
+++ b/Netro Sprinklers.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.4.4</string>
+	<string>2026.5.0</string>
 	<key>ServerApiVersion</key>
 	<string>3.6</string>
 	<key>IwsApiVersion</key>

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -303,6 +303,17 @@
             <Field id="zoneNumber" type="textfield" hidden="true">
                 <Label/>
             </Field>
+            <Field id="sep_sensor" type="separator"/>
+            <Field id="sensorLabel" type="label">
+                <Label>Soil Moisture Source</Label>
+            </Field>
+            <Field id="linkedWhispererDeviceId" type="menu" defaultValue="">
+                <Label>Paired Whisperer:</Label>
+                <List class="self" method="getWhispererDevices" dynamicReload="true"/>
+            </Field>
+            <Field id="sensorHelp" type="label" fontSize="small" fontColor="darkgray" alignWithControl="true">
+                <Label>When paired, the zone's moisture state mirrors the Whisperer's soil reading (if fresh within 12 hours). Otherwise, it shows Netro's daily forecast. The forecast is always available separately as the "Moisture Forecast" state.</Label>
+            </Field>
         </ConfigUI>
         <States>
             <State id="moisture">

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -311,6 +311,8 @@
                 <Label>Paired Whisperer:</Label>
                 <List class="self" method="getWhispererDevices" dynamicReload="true"/>
             </Field>
+            <!-- Help text references "12 hours" — keep in sync with
+                 constants.py::WHISPERER_STALENESS_HOURS if that value changes. -->
             <Field id="sensorHelp" type="label" fontSize="small" fontColor="darkgray" alignWithControl="true">
                 <Label>When paired, the zone's moisture state mirrors the Whisperer's soil reading (if fresh within 12 hours). Otherwise, it shows Netro's daily forecast. The forecast is always available separately as the "Moisture Forecast" state.</Label>
             </Field>

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -310,6 +310,11 @@
                 <TriggerLabel>Moisture Level (%)</TriggerLabel>
                 <ControlPageLabel>Moisture Level (%)</ControlPageLabel>
             </State>
+            <State id="moistureForecast">
+                <ValueType>Integer</ValueType>
+                <TriggerLabel>Moisture Forecast (%)</TriggerLabel>
+                <ControlPageLabel>Moisture Forecast (%)</ControlPageLabel>
+            </State>
             <State id="enabled">
                 <ValueType>Boolean</ValueType>
                 <TriggerLabel>Zone Enabled</TriggerLabel>

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/constants.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/constants.py
@@ -185,6 +185,15 @@ TOKEN_PAUSE_THRESHOLD: Final[int] = 100
 TOKEN_WARNING_THRESHOLD: Final[int] = 200
 """Token count below which warnings are logged."""
 
+WHISPERER_STALENESS_HOURS: Final[int] = 12
+"""Maximum age (hours) for a Whisperer reading to be considered fresh.
+
+Whisperers report every 1-6 hours depending on battery level. 12h = 2-12
+missed readings — tolerates brief API outages but catches a dead battery
+within a day. When a paired Whisperer reading is older than this, the
+zone falls back to Netro's /moistures.json forecast.
+"""
+
 
 # =============================================================================
 # V2 Online Status Values

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/device_handlers.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/device_handlers.py
@@ -698,7 +698,7 @@ class ZoneHandler:
         try:
             moistures = api_response["data"]["moistures"]
             if not moistures:
-                return [{"key": "moisture", "value": 0, "uiValue": "0%"}]
+                return []
 
             moistures_sorted = sorted(moistures, key=lambda x: x.get("id", 0), reverse=True)
             max_date = moistures_sorted[0].get("date")
@@ -708,11 +708,11 @@ class ZoneHandler:
                     val = m.get("moisture", 0)
                     return [{"key": "moisture", "value": val, "uiValue": f"{val}%"}]
 
-            return [{"key": "moisture", "value": 0, "uiValue": "0%"}]
+            return []
 
         except (KeyError, TypeError, IndexError) as exc:
             self.logger.error(f"Error parsing zone moisture: {exc}")
-            return [{"key": "moisture", "value": 0, "uiValue": "0%"}]
+            return []
 
     def extract_zone_states(self, zones, zone_number):
         """Extract enabled and smartMode for a single zone from info data.

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/device_handlers.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/device_handlers.py
@@ -693,7 +693,19 @@ class ZoneHandler:
             zone_number: Zone ith number (1-based)
 
         Returns:
-            List with single moisture state update dict
+            A list containing a single
+            ``{"key": "moisture", "value": int, "uiValue": "<n>%"}`` dict when
+            a reading for ``zone_number`` exists on the most recent date.
+            Returns ``[]`` (empty list) when:
+              - ``moistures`` is empty or missing,
+              - no entry matches ``zone_number`` on the most-recent date, or
+              - the response shape triggers ``KeyError``/``TypeError``/
+                ``IndexError`` (the error is logged via ``self.logger.error``,
+                not raised).
+
+            The empty-list shape signals "no forecast data this cycle" so the
+            caller can skip writing ``moistureForecast`` rather than persisting
+            a fake 0%.
         """
         try:
             moistures = api_response["data"]["moistures"]

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -1227,6 +1227,56 @@ class Plugin(indigo.PluginBase):
         except (TypeError, ValueError):
             return forecast_val, "forecast-stale"
 
+    def _log_moisture_source_transition(self, zone_dev, new_source):
+        """Log a transition between moisture-source categories for a zone.
+
+        Persists the current source in ``zone_dev.pluginProps['lastMoistureSource']``
+        and only emits a log line when the category changes, to avoid spam.
+        The first-ever call on a fresh install is silent (no prior state).
+
+        Args:
+            zone_dev: Indigo zone device.
+            new_source: One of the source tags returned by
+                ``_resolve_zone_moisture``.
+        """
+        prev = zone_dev.pluginProps.get("lastMoistureSource")
+        if prev == new_source:
+            return
+
+        if prev is not None:
+            if new_source == "whisperer":
+                if prev == "forecast-stale":
+                    self.logger.info(
+                        f"Zone '{zone_dev.name}': Whisperer reading recovered — "
+                        f"moisture now tracking paired sensor."
+                    )
+                else:
+                    self.logger.info(
+                        f"Zone '{zone_dev.name}': paired Whisperer reading active — "
+                        f"moisture now tracking sensor."
+                    )
+            elif new_source == "forecast-stale":
+                self.logger.warning(
+                    f"Zone '{zone_dev.name}': paired Whisperer reading stale "
+                    f"(>12h old) — falling back to Netro forecast."
+                )
+            elif new_source == "forecast-missing-device":
+                self.logger.warning(
+                    f"Zone '{zone_dev.name}': paired Whisperer device no longer "
+                    f"exists — falling back to Netro forecast."
+                )
+            elif new_source == "forecast-disabled-device":
+                self.logger.warning(
+                    f"Zone '{zone_dev.name}': paired Whisperer device is disabled "
+                    f"— falling back to Netro forecast."
+                )
+
+        # Persist the new source so the next poll can detect the next transition.
+        new_props = dict(zone_dev.pluginProps)
+        new_props["lastMoistureSource"] = new_source
+        zone_dev.pluginProps = new_props  # keep test-side dict in sync
+        zone_dev.replacePluginPropsOnServer(new_props)
+
     ########################################
     # Validation callbacks
     ########################################

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -749,9 +749,16 @@ class Plugin(indigo.PluginBase):
                                 f"states will not update this cycle."
                             )
 
-                    moisture_val, source = self._resolve_zone_moisture(
-                        zone_dev, forecast_val
-                    )
+                    try:
+                        moisture_val, source = self._resolve_zone_moisture(
+                            zone_dev, forecast_val
+                        )
+                    except (AttributeError, KeyError, TypeError) as exc:
+                        self.logger.warning(
+                            f"Zone '{zone_dev.name}': could not resolve moisture source "
+                            f"({type(exc).__name__}: {exc}) — falling back to forecast."
+                        )
+                        moisture_val, source = forecast_val, "forecast"
                     if moisture_val is not None:
                         states.append({
                             "key": "moisture",
@@ -1290,7 +1297,18 @@ class Plugin(indigo.PluginBase):
             new_source: One of the source tags returned by
                 ``_resolve_zone_moisture``.
         """
-        prev = zone_dev.pluginProps.get("lastMoistureSource")
+        # Lazy-init the in-memory fallback (Plugin.__new__ in tests skips __init__).
+        log_cache = getattr(self, "_last_logged_moisture_source", None)
+        if log_cache is None:
+            log_cache = {}
+            self._last_logged_moisture_source = log_cache
+
+        # Prefer in-memory value when available — it survives IOM persistence
+        # failures, so we don't re-emit the same warning every poll.
+        prev_persisted = zone_dev.pluginProps.get("lastMoistureSource")
+        prev_logged = log_cache.get(zone_dev.id)
+        prev = prev_logged if prev_logged is not None else prev_persisted
+
         if prev == new_source:
             return
 
@@ -1332,16 +1350,23 @@ class Plugin(indigo.PluginBase):
                     f"— falling back to Netro forecast."
                 )
 
-        # Persist the new source so the next poll can detect the next transition.
+        # Update the in-memory marker BEFORE attempting persistence so a
+        # persistence failure doesn't cause repeat-logs next cycle.
+        log_cache[zone_dev.id] = new_source
+
+        # Best-effort persist via Indigo's IOM. Failures are tolerated.
         new_props = dict(zone_dev.pluginProps)
         new_props["lastMoistureSource"] = new_source
         try:
             zone_dev.replacePluginPropsOnServer(new_props)
-        except Exception as exc:
+        # Tolerate any IOM error — the in-memory fallback above ensures we
+        # don't log-spam if persistence is unavailable. Narrowing would
+        # reintroduce fragility against unexpected Indigo exception types.
+        except Exception as exc:  # pylint: disable=broad-exception-caught
             self.logger.warning(
                 f"Zone '{zone_dev.name}': could not persist moisture source "
-                f"'{new_source}' ({type(exc).__name__}: {exc}) — transition "
-                f"log may repeat next cycle."
+                f"'{new_source}' ({type(exc).__name__}: {exc}) — using "
+                f"in-memory fallback so the transition log will not repeat."
             )
 
     ########################################

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -106,6 +106,11 @@ class Plugin(indigo.PluginBase):
         super().__init__(pluginId, pluginDisplayName, pluginVersion, pluginPrefs)
         # Used to control when to show connection errors (vs just repeated retries)
         self._displayed_connection_error = False
+        # In-memory fallback for moisture-source transition logging — keyed by zone
+        # device id. Survives IOM persistence failures so the same transition is
+        # not re-logged every poll. Lazy-init in `_log_moisture_source_transition`
+        # for tests that bypass __init__ via Plugin.__new__(Plugin).
+        self._last_logged_moisture_source = {}
         self.pluginId = pluginId
         self.debug = pluginPrefs.get("showDebugInfo", False)
         self.timeout = int(pluginPrefs.get("apiTimeout", DEFAULT_API_TIMEOUT_SECONDS))

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -1217,14 +1217,18 @@ class Plugin(indigo.PluginBase):
     def _resolve_zone_moisture(self, zone_dev, forecast_val):
         """Resolve the "moisture" state value for a zone device.
 
-        Pure function (no state writes, no logging). Returns a
-        ``(value, source_tag)`` pair where source_tag is one of:
+        Returns a ``(value, source_tag)`` pair where source_tag is one of:
 
         - ``"forecast"``: zone has no paired Whisperer; returns forecast_val.
         - ``"whisperer"``: paired Whisperer exists, is enabled, has a fresh
           (<= WHISPERER_STALENESS_HOURS old) ``soilMoisture`` reading.
-        - ``"forecast-stale"``: paired but reading is missing, too old, or
-          ``readingTime`` is unparseable.
+        - ``"forecast-missing-reading"``: paired but ``readingID`` is 0 (the
+          Indigo Integer-state default — sensor hasn't reported yet) or
+          ``soilMoisture`` is missing/non-numeric.
+        - ``"forecast-unparseable-time"``: paired and reading present but
+          ``readingTime`` cannot be parsed.
+        - ``"forecast-stale"``: paired, readingID > 0, soil numeric, age
+          parsed, but > WHISPERER_STALENESS_HOURS old.
         - ``"forecast-missing-device"``: paired device id does not resolve
           to an Indigo device (deleted or invalid id).
         - ``"forecast-disabled-device"``: paired device exists but is
@@ -1233,6 +1237,9 @@ class Plugin(indigo.PluginBase):
         ``value`` may be ``None`` if forecast_val is None and no Whisperer
         value is available; the caller should skip writing ``moisture`` in
         that case.
+
+        Note: emits a debug breadcrumb (no other logging) when readingTime
+        is unparseable so support debugging has the raw value.
         """
         linked_id = zone_dev.pluginProps.get("linkedWhispererDeviceId", "")
         if not linked_id:
@@ -1246,16 +1253,29 @@ class Plugin(indigo.PluginBase):
         if not whisperer.enabled:
             return forecast_val, "forecast-disabled-device"
 
+        reading_id = whisperer.states.get("readingID") or 0
         soil = whisperer.states.get("soilMoisture")
         reading_time = whisperer.states.get("readingTime", "")
+
+        if reading_id == 0 or soil is None:
+            return forecast_val, "forecast-missing-reading"
+
         age_hours = parse_reading_age_hours(reading_time)
-        if soil is None or age_hours is None or age_hours > WHISPERER_STALENESS_HOURS:
+        if age_hours is None:
+            # Leave a debug breadcrumb with the raw value so support debugging has the data.
+            self.logger.debug(
+                f"Zone '{zone_dev.name}': paired Whisperer readingTime "
+                f"{reading_time!r} is unparseable — treating as stale."
+            )
+            return forecast_val, "forecast-unparseable-time"
+
+        if age_hours > WHISPERER_STALENESS_HOURS:
             return forecast_val, "forecast-stale"
 
         try:
             return int(soil), "whisperer"
         except (TypeError, ValueError):
-            return forecast_val, "forecast-stale"
+            return forecast_val, "forecast-missing-reading"
 
     def _log_moisture_source_transition(self, zone_dev, new_source):
         """Log a transition between moisture-source categories for a zone.
@@ -1289,6 +1309,16 @@ class Plugin(indigo.PluginBase):
                 self.logger.warning(
                     f"Zone '{zone_dev.name}': paired Whisperer reading stale "
                     f"(>12h old) — falling back to Netro forecast."
+                )
+            elif new_source == "forecast-missing-reading":
+                self.logger.warning(
+                    f"Zone '{zone_dev.name}': paired Whisperer has no reading yet "
+                    f"— showing Netro forecast until sensor reports."
+                )
+            elif new_source == "forecast-unparseable-time":
+                self.logger.warning(
+                    f"Zone '{zone_dev.name}': paired Whisperer readingTime is "
+                    f"unparseable — showing Netro forecast. Check Whisperer poll."
                 )
             elif new_source == "forecast-missing-device":
                 self.logger.warning(

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -1229,7 +1229,7 @@ class Plugin(indigo.PluginBase):
 
         - ``"forecast"``: zone has no paired Whisperer; returns forecast_val.
         - ``"whisperer"``: paired Whisperer is enabled, has a fresh
-          (<= WHISPERER_STALENESS_HOURS old) numeric ``soilMoisture`` reading.
+          (≤ WHISPERER_STALENESS_HOURS old) numeric ``soilMoisture`` reading.
         - ``"forecast-missing-device"``: paired device id does not resolve
           (deleted or invalid id).
         - ``"forecast-disabled-device"``: paired device exists but is disabled.
@@ -1241,8 +1241,8 @@ class Plugin(indigo.PluginBase):
           unexpected payload — investigate sensor / API).
         - ``"forecast-unparseable-time"``: paired and reporting numeric soil,
           but ``readingTime`` can't be parsed.
-        - ``"forecast-stale"``: paired, parseable, but reading is older than
-          WHISPERER_STALENESS_HOURS.
+        - ``"forecast-stale"``: paired, parseable, but reading is
+          > WHISPERER_STALENESS_HOURS old.
 
         ``value`` may be ``None`` if forecast_val is None and no Whisperer
         value is available; the caller should skip writing ``moisture`` in
@@ -1295,9 +1295,16 @@ class Plugin(indigo.PluginBase):
     def _log_moisture_source_transition(self, zone_dev, new_source):
         """Log a transition between moisture-source categories for a zone.
 
-        Persists the current source in ``zone_dev.pluginProps['lastMoistureSource']``
-        and only emits a log line when the category changes, to avoid spam.
-        The first-ever call on a fresh install is silent (no prior state).
+        Maintains an in-memory fallback (``_last_logged_moisture_source``) keyed
+        by zone device id so a known-logged transition isn't re-emitted across
+        polls. The persistence side effect (``replacePluginPropsOnServer`` of
+        ``lastMoistureSource``) is best-effort — failures are caught and logged
+        at WARNING, but never propagated, and never block the in-memory
+        suppression. After plugin restart the in-memory cache resets and the
+        first transition per zone is re-emitted from the persisted value.
+
+        Logs are emitted only on category change. The first call on a fresh
+        install (no prior persisted source AND no in-memory entry) is silent.
 
         Args:
             zone_dev: Indigo zone device.

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -1158,6 +1158,28 @@ class Plugin(indigo.PluginBase):
         return [(s.id, s.name) for s in indigo.devices.iter(filter="self")]
 
     ########################################
+    # pylint: disable=unused-argument
+    def getWhispererDevices(self, filter="", valuesDict=None, typeId="", targetId=0):
+        """Populate the `linkedWhispererDeviceId` dropdown on zone ConfigUI.
+
+        Returns a list of (value, label) tuples:
+          - First entry: ("", "(Unpaired — use Netro forecast)") sentinel.
+          - Remaining entries: this plugin's Whisperer devices, sorted
+            case-insensitively by name. Value is the Indigo device ID as a
+            string; label is the device name.
+
+        Called by Indigo when the ConfigUI is opened / reloaded.
+        """
+        options = [("", "(Unpaired — use Netro forecast)")]
+        whisperers = sorted(
+            (d for d in indigo.devices.iter(filter="self")
+             if d.deviceTypeId == "Whisperer"),
+            key=lambda d: d.name.lower(),
+        )
+        options.extend((str(d.id), d.name) for d in whisperers)
+        return options
+
+    ########################################
     # Validation callbacks
     ########################################
     # pylint: disable=unused-argument

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -1222,7 +1222,10 @@ class Plugin(indigo.PluginBase):
         if soil is None or age_hours is None or age_hours > WHISPERER_STALENESS_HOURS:
             return forecast_val, "forecast-stale"
 
-        return int(soil), "whisperer"
+        try:
+            return int(soil), "whisperer"
+        except (TypeError, ValueError):
+            return forecast_val, "forecast-stale"
 
     ########################################
     # Validation callbacks

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -57,6 +57,7 @@ from constants import (
     OPERATIONAL_ERROR_EVENTS,
     COMM_ERROR_EVENTS,
     DEVICE_EVENT_TYPES,
+    WHISPERER_STALENESS_HOURS,
 )
 from exceptions import ThrottleDelayError
 from validators import (
@@ -67,7 +68,11 @@ from validators import (
 )
 from api_client import NetroAPIClient
 from device_handlers import SprinklerHandler, WhispererHandler, ZoneHandler
-from utils import convert_weather_us_to_metric, convert_weather_metric_to_us
+from utils import (
+    convert_weather_us_to_metric,
+    convert_weather_metric_to_us,
+    parse_reading_age_hours,
+)
 from tomorrow_client import TomorrowClient
 
 
@@ -1178,6 +1183,46 @@ class Plugin(indigo.PluginBase):
         )
         options.extend((str(d.id), d.name) for d in whisperers)
         return options
+
+    def _resolve_zone_moisture(self, zone_dev, forecast_val):
+        """Resolve the "moisture" state value for a zone device.
+
+        Pure function (no state writes, no logging). Returns a
+        ``(value, source_tag)`` pair where source_tag is one of:
+
+        - ``"forecast"``: zone has no paired Whisperer; returns forecast_val.
+        - ``"whisperer"``: paired Whisperer exists, is enabled, has a fresh
+          (<= WHISPERER_STALENESS_HOURS old) ``soilMoisture`` reading.
+        - ``"forecast-stale"``: paired but reading is missing, too old, or
+          ``readingTime`` is unparseable.
+        - ``"forecast-missing-device"``: paired device id does not resolve
+          to an Indigo device (deleted or invalid id).
+        - ``"forecast-disabled-device"``: paired device exists but is
+          disabled in Indigo.
+
+        ``value`` may be ``None`` if forecast_val is None and no Whisperer
+        value is available; the caller should skip writing ``moisture`` in
+        that case.
+        """
+        linked_id = zone_dev.pluginProps.get("linkedWhispererDeviceId", "")
+        if not linked_id:
+            return forecast_val, "forecast"
+
+        try:
+            whisperer = indigo.devices[int(linked_id)]
+        except (KeyError, ValueError):
+            return forecast_val, "forecast-missing-device"
+
+        if not whisperer.enabled:
+            return forecast_val, "forecast-disabled-device"
+
+        soil = whisperer.states.get("soilMoisture")
+        reading_time = whisperer.states.get("readingTime", "")
+        age_hours = parse_reading_age_hours(reading_time)
+        if soil is None or age_hours is None or age_hours > WHISPERER_STALENESS_HOURS:
+            return forecast_val, "forecast-stale"
+
+        return int(soil), "whisperer"
 
     ########################################
     # Validation callbacks

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -734,11 +734,14 @@ class Plugin(indigo.PluginBase):
                             forecast_states = self.zone_handler.process_zone_moisture(
                                 moisture_response, zone_num
                             )
+                            found = False
                             for entry in forecast_states:
-                                if entry.get("key") == "moisture":
-                                    entry["key"] = "moistureForecast"
+                                if not found and entry.get("key") == "moisture":
                                     forecast_val = entry.get("value")
-                            states.extend(forecast_states)
+                                    states.append({**entry, "key": "moistureForecast"})
+                                    found = True
+                                else:
+                                    states.append(entry)
                         except Exception:
                             self.logger.exception(
                                 f"Error processing moisture for zone {zone_num} "

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -1300,7 +1300,6 @@ class Plugin(indigo.PluginBase):
         # Persist the new source so the next poll can detect the next transition.
         new_props = dict(zone_dev.pluginProps)
         new_props["lastMoistureSource"] = new_source
-        zone_dev.pluginProps = new_props  # keep test-side dict in sync
         zone_dev.replacePluginPropsOnServer(new_props)
 
     ########################################

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -757,10 +757,14 @@ class Plugin(indigo.PluginBase):
                             "value": moisture_val,
                             "uiValue": f"{moisture_val}%",
                         })
-                    self._log_moisture_source_transition(zone_dev, source)
 
+                # State write FIRST — it's the authoritative side effect.
                 if states:
                     zone_dev.updateStatesOnServer(states)
+
+                # Transition log is auxiliary; must not gate the state write.
+                if is_enabled:
+                    self._log_moisture_source_transition(zone_dev, source)
 
                 # Set error state and icon after state update
                 if not is_enabled:
@@ -1300,7 +1304,14 @@ class Plugin(indigo.PluginBase):
         # Persist the new source so the next poll can detect the next transition.
         new_props = dict(zone_dev.pluginProps)
         new_props["lastMoistureSource"] = new_source
-        zone_dev.replacePluginPropsOnServer(new_props)
+        try:
+            zone_dev.replacePluginPropsOnServer(new_props)
+        except Exception as exc:
+            self.logger.warning(
+                f"Zone '{zone_dev.name}': could not persist moisture source "
+                f"'{new_source}' ({type(exc).__name__}: {exc}) — transition "
+                f"log may repeat next cycle."
+            )
 
     ########################################
     # Validation callbacks

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -742,10 +742,11 @@ class Plugin(indigo.PluginBase):
                                     found = True
                                 else:
                                     states.append(entry)
-                        except Exception:
+                        except (AttributeError, TypeError, KeyError, IndexError):
                             self.logger.exception(
-                                f"Error processing moisture for zone {zone_num} "
-                                f"on '{zone_dev.name}'"
+                                f"Error processing moisture for zone {zone_num} on "
+                                f"'{zone_dev.name}' — moisture + moistureForecast "
+                                f"states will not update this cycle."
                             )
 
                     moisture_val, source = self._resolve_zone_moisture(

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -728,10 +728,33 @@ class Plugin(indigo.PluginBase):
                             )
                         )
 
+                    forecast_val = None
                     if moisture_response:
-                        states.extend(
-                            self.zone_handler.process_zone_moisture(moisture_response, zone_num)
-                        )
+                        try:
+                            forecast_states = self.zone_handler.process_zone_moisture(
+                                moisture_response, zone_num
+                            )
+                            for entry in forecast_states:
+                                if entry.get("key") == "moisture":
+                                    entry["key"] = "moistureForecast"
+                                    forecast_val = entry.get("value")
+                            states.extend(forecast_states)
+                        except Exception:
+                            self.logger.exception(
+                                f"Error processing moisture for zone {zone_num} "
+                                f"on '{zone_dev.name}'"
+                            )
+
+                    moisture_val, source = self._resolve_zone_moisture(
+                        zone_dev, forecast_val
+                    )
+                    if moisture_val is not None:
+                        states.append({
+                            "key": "moisture",
+                            "value": moisture_val,
+                            "uiValue": f"{moisture_val}%",
+                        })
+                    self._log_moisture_source_transition(zone_dev, source)
 
                 if states:
                     zone_dev.updateStatesOnServer(states)

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -1228,26 +1228,29 @@ class Plugin(indigo.PluginBase):
         Returns a ``(value, source_tag)`` pair where source_tag is one of:
 
         - ``"forecast"``: zone has no paired Whisperer; returns forecast_val.
-        - ``"whisperer"``: paired Whisperer exists, is enabled, has a fresh
-          (<= WHISPERER_STALENESS_HOURS old) ``soilMoisture`` reading.
-        - ``"forecast-missing-reading"``: paired but ``readingID`` is 0 (the
-          Indigo Integer-state default — sensor hasn't reported yet) or
-          ``soilMoisture`` is missing/non-numeric.
-        - ``"forecast-unparseable-time"``: paired and reading present but
-          ``readingTime`` cannot be parsed.
-        - ``"forecast-stale"``: paired, readingID > 0, soil numeric, age
-          parsed, but > WHISPERER_STALENESS_HOURS old.
+        - ``"whisperer"``: paired Whisperer is enabled, has a fresh
+          (<= WHISPERER_STALENESS_HOURS old) numeric ``soilMoisture`` reading.
         - ``"forecast-missing-device"``: paired device id does not resolve
-          to an Indigo device (deleted or invalid id).
-        - ``"forecast-disabled-device"``: paired device exists but is
-          disabled in Indigo.
+          (deleted or invalid id).
+        - ``"forecast-disabled-device"``: paired device exists but is disabled.
+        - ``"forecast-missing-reading"``: paired but the sensor has not
+          reported yet — ``readingID`` is 0 (Indigo Integer-state default)
+          or ``soilMoisture`` is None.
+        - ``"forecast-invalid-reading"``: paired and reporting, but
+          ``soilMoisture`` is present and not coercible to int (corrupt or
+          unexpected payload — investigate sensor / API).
+        - ``"forecast-unparseable-time"``: paired and reporting numeric soil,
+          but ``readingTime`` can't be parsed.
+        - ``"forecast-stale"``: paired, parseable, but reading is older than
+          WHISPERER_STALENESS_HOURS.
 
         ``value`` may be ``None`` if forecast_val is None and no Whisperer
         value is available; the caller should skip writing ``moisture`` in
         that case.
 
         Note: emits a debug breadcrumb (no other logging) when readingTime
-        is unparseable so support debugging has the raw value.
+        is unparseable or soilMoisture is non-numeric, so support debugging
+        has the raw values.
         """
         linked_id = zone_dev.pluginProps.get("linkedWhispererDeviceId", "")
         if not linked_id:
@@ -1283,7 +1286,11 @@ class Plugin(indigo.PluginBase):
         try:
             return int(soil), "whisperer"
         except (TypeError, ValueError):
-            return forecast_val, "forecast-missing-reading"
+            self.logger.debug(
+                f"Zone '{zone_dev.name}': paired Whisperer soilMoisture "
+                f"{soil!r} is non-numeric — treating as invalid reading."
+            )
+            return forecast_val, "forecast-invalid-reading"
 
     def _log_moisture_source_transition(self, zone_dev, new_source):
         """Log a transition between moisture-source categories for a zone.
@@ -1333,6 +1340,12 @@ class Plugin(indigo.PluginBase):
                 self.logger.warning(
                     f"Zone '{zone_dev.name}': paired Whisperer has no reading yet "
                     f"— showing Netro forecast until sensor reports."
+                )
+            elif new_source == "forecast-invalid-reading":
+                self.logger.warning(
+                    f"Zone '{zone_dev.name}': paired Whisperer reported a "
+                    f"non-numeric soil value — showing Netro forecast. Check "
+                    f"sensor firmware or Netro API response."
                 )
             elif new_source == "forecast-unparseable-time":
                 self.logger.warning(

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/utils.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/utils.py
@@ -169,7 +169,7 @@ def parse_reading_age_hours(
 
     # Try ISO 8601 first (covers v2 and any pre-formatted strings).
     if isinstance(reading_time, str):
-        candidate = reading_time.rstrip("Z").strip()
+        candidate = reading_time.removesuffix("Z").strip()
         try:
             parsed = datetime.fromisoformat(candidate)
         except ValueError:
@@ -187,7 +187,8 @@ def parse_reading_age_hours(
             return None
 
     # Epoch millis (int or float from numeric-string fallthrough above).
-    if isinstance(reading_time, (int, float)):
+    # Reject bool explicitly — bool is a subclass of int.
+    if isinstance(reading_time, (int, float)) and not isinstance(reading_time, bool):
         try:
             seconds = float(reading_time) / 1000.0
             parsed = datetime.fromtimestamp(seconds, tz=timezone.utc)

--- a/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/utils.py
+++ b/Netro Sprinklers.indigoPlugin/Contents/Server Plugin/utils.py
@@ -6,6 +6,8 @@ This module provides common utility functions used throughout the plugin:
   rainfall, wind speed, and pressure
 - Weather data conversion: convert_weather_us_to_metric / convert_weather_metric_to_us
   for transforming weather dicts between API v1 (US) and v2 (metric) formats
+- parse_reading_age_hours: Parse Whisperer reading timestamps (v1 epoch millis
+  or v2 ISO 8601) and return age in hours
 - get_key_from_dict: Safely retrieve values from dictionaries
 
 These functions are extracted from plugin.py to enable reuse and testing.
@@ -15,7 +17,8 @@ Note:
     It has no dependencies on other plugin modules to prevent circular imports.
 """
 
-from typing import Any, Dict
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Union
 
 
 def fahrenheit_to_celsius(f: float) -> float:
@@ -124,6 +127,76 @@ def convert_weather_metric_to_us(weather_data: Dict[str, Any]) -> Dict[str, Any]
         converted["pressure"] = round(hpa_to_inhg(float(converted["pressure"])), 2)
 
     return converted
+
+
+def _now_utc() -> datetime:
+    """Return current time as a timezone-aware UTC datetime.
+
+    Indirected through a module-level function so tests can patch it
+    deterministically without depending on freezegun or similar.
+    """
+    return datetime.now(tz=timezone.utc)
+
+
+def parse_reading_age_hours(
+    reading_time: Union[str, int, float, None]
+) -> Optional[float]:
+    """Compute age (hours) of a Whisperer reading timestamp.
+
+    Accepts both API v1 and v2 timestamp formats emitted by
+    ``WhispererHandler.process_sensor_data``:
+
+    - **V1 (epoch millis)**: e.g. ``1234567890000`` (int or numeric string)
+    - **V2 (ISO 8601)**: e.g. ``"2026-04-07T10:00:00"`` or ``"...Z"``
+
+    Args:
+        reading_time: Value from the Whisperer ``readingTime`` state.
+
+    Returns:
+        Age in hours (non-negative float) if parseable, ``None`` otherwise.
+        Returns ``0.0`` when the reading is in the future (clock skew).
+
+    Note:
+        V2 ISO strings without an explicit timezone are assumed to be UTC.
+        Netro's ``time`` field is the sensor's UTC timestamp; ``local_time``
+        is the pre-formatted local variant. We intentionally use the UTC
+        form for age math to avoid DST/tz drift.
+    """
+    if reading_time is None or reading_time == "":
+        return None
+
+    now = _now_utc()
+
+    # Try ISO 8601 first (covers v2 and any pre-formatted strings).
+    if isinstance(reading_time, str):
+        candidate = reading_time.rstrip("Z").strip()
+        try:
+            parsed = datetime.fromisoformat(candidate)
+        except ValueError:
+            parsed = None
+        else:
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            delta = (now - parsed).total_seconds() / 3600.0
+            return max(0.0, delta)
+
+        # Fall through: maybe it's a stringified epoch millis.
+        try:
+            reading_time = int(candidate)
+        except (TypeError, ValueError):
+            return None
+
+    # Epoch millis (int or float from numeric-string fallthrough above).
+    if isinstance(reading_time, (int, float)):
+        try:
+            seconds = float(reading_time) / 1000.0
+            parsed = datetime.fromtimestamp(seconds, tz=timezone.utc)
+        except (OSError, OverflowError, ValueError):
+            return None
+        delta = (now - parsed).total_seconds() / 3600.0
+        return max(0.0, delta)
+
+    return None
 
 
 def get_key_from_dict(key: str, data: dict, default: Any = None) -> Any:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ Track your daily API call usage directly from Indigo device states. The Netro AP
 
 Integrate Whisperer soil sensors to monitor temperature, humidity, and moisture levels independently of your sprinkler zones.
 
+### Pairing a Whisperer to a Zone
+
+Each zone device has a **Paired Whisperer** dropdown in its config UI.
+When paired and the Whisperer has reported within the last 12 hours,
+the zone's `moisture` state mirrors the Whisperer's `soilMoisture`
+reading (the actual measured value). Otherwise the zone falls back to
+Netro's daily forecast.
+
+The `/moistures.json` forecast is always visible separately on the
+`moistureForecast` state — useful for comparing model predictions to
+the sensor's ground truth, and for tuning schedules. See
+[`docs/API_NOTES.md`](docs/API_NOTES.md) §6 for details.
+
 ### Indigo Triggers
 
 Create automations based on sprinkler events:

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -196,7 +196,7 @@ disagree. Observed example: same zone, same moment — `/moistures.json`
   `/moistures.json` value.
 - The zone `moisture` state resolves to: the paired Whisperer's current
   `soilMoisture` if the pairing is configured on the zone device and
-  the reading is less than 12 hours old, else `moistureForecast`.
+  the reading is ≤ 12 hours old (see `WHISPERER_STALENESS_HOURS`), else `moistureForecast`.
 - Pairing is plugin-side (zone ConfigUI → "Paired Whisperer" dropdown),
   independent of any Netro-side pairing. Both can coexist; they don't
   interact.

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -1,0 +1,443 @@
+# Netro API Notes & Quirks
+
+Documentation of Netro Public API (NPA) quirks, limitations, and undocumented behavior discovered during development and testing.
+
+## API Overview
+
+- **Base URL**: `http://api.netrohome.com/npa/v1/`
+- **Authentication**: Device serial number as URL parameter (`?key={serial}`)
+- **Rate Limit**: 2000 calls per day per serial number
+- **Response Format**: JSON
+- **HTTP Methods**: GET, POST, PUT
+
+## Known Quirks
+
+### 1. Timestamp Format Inconsistency
+
+**Issue**: API docs say timestamps are numbers, but API returns strings
+
+**Discovered**: Live testing (commit 9e93000)
+
+**Example**:
+```json
+{
+  "start_time": "1740664800000"  // String, not number!
+}
+```
+
+**Workaround**:
+```python
+# Handle both string and number
+start_time_raw = data.get("start_time", 0)
+try:
+    start_time = float(start_time_raw) if isinstance(start_time_raw, str) else start_time_raw
+except (ValueError, TypeError):
+    start_time = 0
+```
+
+**Affected Fields**:
+- `start_time` in schedules
+- `time` in various responses
+- Any Unix timestamp field
+
+**Fixed in**: plugin.py lines 309-314, 337-344
+
+### 2. Device vs Devices Response
+
+**Issue**: Inconsistent array/object response structure
+
+**API documentation says**: Returns `devices` array
+
+**Reality**: Returns single `device` object
+
+**Example**:
+```json
+{
+  "status": "OK",
+  "data": {
+    "device": {          // Singular!
+      "serial": "...",
+      "name": "...",
+      "zones": [...]
+    }
+  }
+}
+```
+
+**Not**:
+```json
+{
+  "data": {
+    "devices": [...]     // This doesn't exist
+  }
+}
+```
+
+**Workaround**:
+```python
+device = reply_dict["data"]["device"]  // Not devices[0]
+```
+
+**Fixed in**: plugin.py line 233, test_local_api.py line 98
+
+### 3. Offline Status Quirks
+
+**Issue**: Controller status changes are slow and inconsistent
+
+**Observations from live testing**:
+
+**When controller turned OFF**:
+- Status changes from "ONLINE" to "STANDBY" (not "OFFLINE"!)
+- Schedules reduce from 50 to 2
+- Last active timestamp updates
+- Can take 5-10 minutes to reflect in API
+
+**When controller turned ON**:
+- Status changes from "STANDBY" to "ONLINE"
+- Schedules repopulate
+- Can take even longer (10+ minutes)
+
+**Implications**:
+- Don't rely on immediate status changes
+- "STANDBY" can mean either user-set standby OR offline
+- Use `last_active` timestamp for better offline detection
+
+### 4. Smart Schedule Types
+
+**Issue**: Underdocumented schedule source types
+
+**Observed values**:
+- `"AUTOMATIC"` - Auto-generated smart schedule
+- `"MANUAL"` - User-created manual schedule
+- `"SMART"` - Smart schedule variant
+- `"FIX"` - Fixed schedule
+- Others unknown
+
+**Also seen**:
+- `smart` field can be boolean `true`/`false`
+- OR string `"SMART"`/`"MANUAL"`
+
+**Workaround**:
+```python
+smart = zone.get('smart', 'MANUAL')
+# Handle both boolean and string
+if isinstance(smart, bool):
+    smart_str = "SMART" if smart else "MANUAL"
+else:
+    smart_str = smart
+```
+
+### 5. API Rate Limiting Behavior
+
+**Issue**: Undocumented throttle response format
+
+**When rate limit exceeded**:
+- HTTP 429 response
+- No specific error message in JSON
+- Plugin must track throttle state locally
+
+**Token tracking**:
+```json
+{
+  "meta": {
+    "token_remaining": 1847,
+    "token_reset": 1609545600  // Unix timestamp
+  }
+}
+```
+
+**Observations**:
+- Token count decreases by 1 per call
+- Resets at midnight UTC
+- Going over limit triggers 61-minute lockout
+- Subsequent calls during lockout also return 429
+
+**Best practices**:
+- Check `token_remaining` in every response
+- Warn user when <100 remaining
+- Implement exponential backoff if needed
+
+### 6. `/moistures.json` — predictions, not sensor readings
+
+**Issue**: `/moistures.json` returns Netro's **smart-model daily prediction**
+for each zone, *not* a sampled sensor value. The model assumes full
+saturation immediately after irrigation, then decays based on local
+weather inputs.
+
+For a zone with **no** paired Whisperer, this is the best signal
+available. For a zone **with** a paired Whisperer (pairing done in the
+Netro mobile app), Netro's app overlays the Whisperer's reading on the
+zone tile, but **the `/moistures.json` response itself continues to
+return the prediction** — the public API does not expose the app-side
+overlay.
+
+This means the plugin's zone `moisture` state will diverge from a
+paired Whisperer's actual reading whenever the model and reality
+disagree. Observed example: same zone, same moment — `/moistures.json`
+= 89%, paired Whisperer = 24%.
+
+**Response format**:
+```json
+{
+  "moistures": [
+    {
+      "id": 12345,
+      "zone": 1,
+      "moisture": 45,
+      "date": "2025-01-27"
+    }
+  ]
+}
+```
+
+**Plugin behavior**:
+
+- The zone `moistureForecast` state always holds the raw
+  `/moistures.json` value.
+- The zone `moisture` state resolves to: the paired Whisperer's current
+  `soilMoisture` if the pairing is configured on the zone device and
+  the reading is less than 12 hours old, else `moistureForecast`.
+- Pairing is plugin-side (zone ConfigUI → "Paired Whisperer" dropdown),
+  independent of any Netro-side pairing. Both can coexist; they don't
+  interact.
+
+**Workarounds** (when consuming the raw feed):
+- Sort by ID to get most recent: `sort(key=lambda x: x['id'], reverse=True)`
+- Filter by most recent date
+- Show date with moisture value so users understand it is a daily
+  prediction, not a live reading
+
+**Open empirical question**: whether `/moistures.json` continues to
+produce sane predictions when a Whisperer is paired on Netro's side but
+has stopped reporting (dead battery, unplugged). The issue-#54
+investigation showed `/moistures.json` returning a saturation-based
+prediction even with a working paired Whisperer, suggesting the
+prediction is independent of Whisperer reporting state. Recommend
+dogfooding with a disconnected Whisperer for a week before relying on
+the fallback in production.
+
+### 7. Whisperer Sensor Reporting
+
+**Issue**: Sensor update frequency is variable
+
+**Observations**:
+- Sensors report every 4-6 hours normally
+- Can be longer if battery low
+- No way to force immediate update
+- Battery level crucial - <20% = unreliable
+
+**Response structure**:
+```json
+{
+  "sensor_data": [
+    {
+      "id": 123,
+      "moisture": 45,
+      "celsius": 22,
+      "fahrenheit": 72,
+      "sunlight": 1200,
+      "battery_level": 85,
+      "time": "...",
+      "local_date": "2025-01-27",
+      "local_time": "14:30:00"
+    }
+  ]
+}
+```
+
+**Field notes**:
+- `local_date` and `local_time` are STRINGS (not swapped anymore - fixed in commit 617a630)
+- `battery_level` is percentage (0-100)
+- `sunlight` is in lux
+- Most recent reading is first after sorting by ID
+
+### 8. Weather Reporting Quirks
+
+**Issue**: Weather parameters poorly documented
+
+**Required fields**:
+- `key`: Serial number
+- `t`: Current temperature (Fahrenheit)
+- `date`: YYYY-MM-DD format
+
+**Optional fields**:
+- `t_max`, `t_min`: High/low temperature
+- `humidity`: 0-100 percentage
+- `condition`: Weather code (0=clear, others undocumented)
+- `rain`: Rainfall amount (units unclear)
+- `rain_prob`: Rain probability 0-100
+- `wind_speed`: Wind speed (units unclear - likely mph)
+- `pressure`: Atmospheric pressure (units unclear - likely inHg)
+
+**Condition codes** (observed/guessed):
+```
+0  = Clear
+1  = Cloudy?
+2  = Rain?
+3+ = Unknown
+```
+
+**Note**: Weather reporting doesn't trigger immediate schedule changes
+
+### 9. Zone Control Limitations
+
+**What works**:
+- ✅ Start individual zone with duration
+- ✅ Stop all zones
+- ✅ Set rain delay
+- ✅ Set standby mode
+
+**What doesn't work** (API limitations):
+- ❌ Pause/resume individual zones
+- ❌ Skip to next zone in schedule
+- ❌ Go back to previous zone
+- ❌ Modify zone duration while running
+- ❌ Create/modify schedules via API
+- ❌ Change zone settings (soil type, etc.)
+
+**Advanced features** (available but less tested):
+- `delay`: Minutes before starting (0-60)
+- `start_time`: Schedule for future (Unix timestamp)
+
+### 10. Error Response Format
+
+**Issue**: Inconsistent error responses
+
+**Success**:
+```json
+{
+  "status": "OK",
+  "data": {...},
+  "meta": {...}
+}
+```
+
+**Error examples**:
+```json
+// HTTP 401
+{
+  "status": "ERROR",
+  "error": "Invalid key"
+}
+
+// HTTP 429
+{
+  "status": "ERROR",
+  "error": "Rate limit exceeded"
+}
+
+// HTTP 500
+{
+  "status": "ERROR",
+  "error": "Internal server error"
+}
+```
+
+**Sometimes**: Just HTTP status code, no JSON body
+
+**Workaround**: Check HTTP status first, then parse JSON if available
+
+## Testing Observations
+
+### Live Testing Results (Jan 2025)
+
+**Test controller**: "Clark Castle Spark"
+- Serial: 0cb8152f9f78
+- 16 zones total
+- 8 enabled zones
+- API tokens: 1665/2000 remaining
+
+**When ONLINE**:
+- 50 schedules returned
+- Status: "ONLINE"
+- All zone data populated
+
+**When OFFLINE** (controller powered off):
+- 2 schedules returned (down from 50)
+- Status: "STANDBY" (not "OFFLINE"!)
+- Historical moisture data still available
+- `last_active` timestamp updates when status changes
+
+**Polling behavior**:
+- 3-minute interval: ~480 calls/day (safe)
+- 5-minute interval: ~288 calls/day (very safe)
+- 1-minute interval: ~1440 calls/day (risky!)
+
+## Recommendations
+
+### For Plugin Developers
+
+1. **Always handle both string and number timestamps**
+2. **Don't assume response structure matches docs**
+3. **Test with controller both online and offline**
+4. **Implement generous error handling**
+5. **Log API responses in debug mode**
+6. **Check token_remaining in every response**
+7. **Use conservative polling intervals (5+ minutes)**
+
+### For Users
+
+1. **Increase polling interval if approaching rate limit**
+2. **Don't rely on immediate status updates**
+3. **Use Netro app for zone configuration**
+4. **Replace sensor batteries when <20%**
+5. **Allow 10-15 minutes for status changes**
+
+## Useful Testing Commands
+
+### Test API directly:
+```bash
+# Device info
+curl "http://api.netrohome.com/npa/v1/info.json?key=YOUR_SERIAL"
+
+# Schedules
+curl "http://api.netrohome.com/npa/v1/schedules.json?key=YOUR_SERIAL"
+
+# Moisture
+curl "http://api.netrohome.com/npa/v1/moistures.json?key=YOUR_SERIAL"
+```
+
+### Use test script:
+```bash
+python3 test_local_api.py --serial YOUR_SERIAL
+```
+
+See [LOCAL_TESTING.md](LOCAL_TESTING.md) for details.
+
+## API Documentation
+
+Official (limited) docs:
+- https://www.netrohome.com/en/shop/articles/10
+
+Better info sources:
+- This file (API_NOTES.md)
+- [NETRO_API.md](NETRO_API.md) - Full endpoint documentation
+- test_local_api.py source code
+- plugin.py _make_api_call() implementation
+
+## Version History
+
+**Discoveries by version**:
+- v1.0 (initial): Basic API integration
+- v2.0 (overhaul): 
+  - Timestamp string/number handling (commit 9e93000)
+  - Device vs devices fix (commit 617a630)
+  - Offline status observations (Jan 2025 testing)
+  - Token warning thresholds added
+  - All quirks documented in this file
+
+## Future Watch List
+
+**Behaviors to monitor**:
+- Schedule type values (may discover new types)
+- Weather condition codes (need complete list)
+- Error response formats (may vary)
+- New API endpoints (if Netro adds features)
+- Rate limit policy changes
+
+**Report issues**:
+- Unexpected API responses
+- New schedule types
+- Different error formats
+- Undocumented fields
+

--- a/docs/plans/2026-04-23-whisperer-zone-pairing-design.md
+++ b/docs/plans/2026-04-23-whisperer-zone-pairing-design.md
@@ -1,0 +1,331 @@
+# Whisperer ↔ Zone pairing — design
+
+**Issue:** [#54](https://github.com/simons-plugins/netro-indigo/issues/54)
+**Date:** 2026-04-23
+**Status:** Accepted
+
+## Problem
+
+Netro's `/moistures.json` returns a **smart-model daily prediction** for each
+zone — not the paired Whisperer's sensor reading. The Netro mobile app
+overlays the Whisperer reading on the zone tile when one is paired; the
+public API does not. Result: the Indigo plugin's zone `moisture` state can
+diverge dramatically from a paired Whisperer's actual reading (observed:
+zone 89% vs Whisperer 24% on the same zone, same moment).
+
+The plugin already reads both values correctly, but they land on separate
+Indigo devices with no linkage, so control pages, triggers, and schedules
+keyed on zone `moisture` use the forecast, not the sensor.
+
+## Goals
+
+1. Let the user explicitly pair a Whisperer device to a zone device in the
+   plugin (no auto-matching).
+2. When paired and the Whisperer reading is fresh, zone `moisture` reflects
+   the real sensor.
+3. Keep the Netro forecast observable alongside (for comparison, schedule
+   tuning, and transparent fallback when the sensor goes stale).
+4. No Netro API changes — pairing lives entirely in plugin-side state.
+
+## Non-goals
+
+- Auto-pairing by zone/Whisperer name similarity.
+- Pairing multiple Whisperers to one zone.
+- Writing sensor data back to Netro (we already expose a `set_moisture`
+  action; that's unchanged).
+
+## Architecture & data flow
+
+### State model
+
+On the zone device:
+
+- `moisture` (existing, semantics change) — "best available" reading:
+  Whisperer if paired and fresh, else the Netro forecast.
+- `moistureForecast` (new) — always Netro's `/moistures.json` daily
+  prediction. Exposes the prediction even when a Whisperer overrides
+  `moisture`, so the user can compare model vs reality and tune schedules.
+
+A new pluginProp on the zone device:
+
+- `linkedWhispererDeviceId` — string holding the Indigo device ID of the
+  paired Whisperer, or empty string (= unpaired). Set via a new dropdown
+  in the zone ConfigUI.
+
+### Update flow (per zone, on every zone-update cycle)
+
+```
+1. Build states from info + schedule data (unchanged).
+2. If moistures_response is available:
+     forecast_val = ZoneHandler.process_zone_moisture(...)
+     write moistureForecast = forecast_val
+   Else:
+     forecast_val = None  (don't overwrite moistureForecast this cycle)
+3. moisture_val, source = _resolve_zone_moisture(zone_dev, forecast_val):
+     - No pairing / device missing / disabled  → forecast_val, "forecast"
+     - Paired, fresh (age ≤ 12h)                → Whisperer.soilMoisture, "whisperer"
+     - Paired, stale (age > 12h)                → forecast_val, "forecast-stale"
+4. If moisture_val is not None:
+     write moisture = moisture_val, uiValue = "N%"
+5. replaceOnServer (unchanged batch write).
+```
+
+The Whisperer update loop is unchanged — it still writes only its own
+device states. No cross-device writes. The zone loop pulls Whisperer
+state out of Indigo's device DB when it runs.
+
+### Design decisions
+
+| Decision | Choice | Reason |
+|---|---|---|
+| Fallback when paired-but-stale | Fall back to `moistureForecast` | Matches the Netro app's behavior: if the sensor is gone, schedules use the prediction. User can also unpair on the Netro side to force prediction-only mode. |
+| Staleness threshold | 12 hours, hardcoded | Whisperers report every 1–6h depending on battery. 12h = 2–12 missed readings, survives brief outages but catches a dead battery within a day. |
+| Who writes `moisture` | Zone update loop pulls from Whisperer device | Single writer, staleness logic in one place. Up to ~10min lag — irrelevant for soil moisture. |
+| ConfigUI layout | Separator + section label + dropdown + help text | Matches existing style (Whisperer's `sep_api` pattern). |
+| Auto-pair by name | No | Explicit config only — prevents brittle matching and silent surprises. |
+
+### Netro-side pairing (open empirical question)
+
+The issue's investigation showed `/moistures.json` returning a
+saturation-based prediction (89%) while a working paired Whisperer read
+24% at the same moment — suggesting Netro's prediction is independent of
+Whisperer pairing on Netro's side. We rely on this: when a Whisperer is
+paired in Netro but stops reporting (dead battery, unplugged), we assume
+`/moistures.json` keeps producing useful predictions. This should be
+dogfooded for a week with a physically disconnected Whisperer before
+shipping broadly. Documented in `API_NOTES.md`.
+
+User workflow if a Whisperer dies: either leave it in place (our 12h
+fallback takes over after the last reading ages out), or unpair in the
+Netro app to force Netro-side prediction-only mode. Our plugin-side
+pairing is separate from Netro-side pairing — both can coexist.
+
+## Code changes
+
+### `Devices.xml` — zone device (around line 297)
+
+Add a new visible section to `<ConfigUI>`:
+
+```xml
+<Field id="sep_sensor" type="separator"/>
+<Field id="sensorLabel" type="label">
+    <Label>Soil Moisture Source</Label>
+</Field>
+<Field id="linkedWhispererDeviceId" type="menu" defaultValue="">
+    <Label>Paired Whisperer:</Label>
+    <List class="self" method="getWhispererDevices" dynamicReload="true"/>
+</Field>
+<Field id="sensorHelp" type="label" fontSize="small" fontColor="darkgray"
+       alignWithControl="true">
+    <Label>When paired, the zone's moisture state mirrors the Whisperer's
+    soil reading (if fresh within 12 hours). Otherwise, it shows Netro's
+    daily forecast. The forecast is always available separately as
+    "moistureForecast".</Label>
+</Field>
+```
+
+Add a new state:
+
+```xml
+<State id="moistureForecast">
+    <ValueType>Integer</ValueType>
+    <TriggerLabel>Moisture Forecast (%)</TriggerLabel>
+    <ControlPageLabel>Moisture Forecast (%)</ControlPageLabel>
+</State>
+```
+
+`<UiDisplayStateId>moisture</UiDisplayStateId>` unchanged — zone tiles keep
+showing the "best available" value, which is the right default.
+
+### `plugin.py` — new dynamic list callback
+
+```python
+def getWhispererDevices(self, filter="", valuesDict=None, typeId="", targetId=0):
+    """Populate linkedWhispererDeviceId dropdown on zone ConfigUI."""
+    options = [("", "(Unpaired — use Netro forecast)")]
+    whisperers = sorted(
+        (d for d in indigo.devices.iter(filter="self")
+         if d.deviceTypeId == "Whisperer"),
+        key=lambda d: d.name.lower(),
+    )
+    options.extend((str(d.id), d.name) for d in whisperers)
+    return options
+```
+
+### `plugin.py` — new helper `_resolve_zone_moisture`
+
+```python
+def _resolve_zone_moisture(self, zone_dev, forecast_val):
+    """Resolve the "moisture" state value for a zone device.
+
+    Returns (value_or_none, source_tag) where source_tag is one of:
+        "forecast", "whisperer", "forecast-stale",
+        "forecast-missing-device", "forecast-disabled-device".
+    """
+    linked_id = zone_dev.pluginProps.get("linkedWhispererDeviceId", "")
+    if not linked_id:
+        return forecast_val, "forecast"
+
+    try:
+        whisperer = indigo.devices[int(linked_id)]
+    except (KeyError, ValueError):
+        return forecast_val, "forecast-missing-device"
+
+    if not whisperer.enabled:
+        return forecast_val, "forecast-disabled-device"
+
+    soil = whisperer.states.get("soilMoisture")
+    reading_time = whisperer.states.get("readingLocalTime", "")
+    age_hours = _parse_reading_age_hours(reading_time)  # util helper
+    if soil is None or age_hours is None or age_hours > WHISPERER_STALENESS_HOURS:
+        return forecast_val, "forecast-stale"
+
+    return int(soil), "whisperer"
+```
+
+### `plugin.py` — `_update_zone_devices` call site
+
+After the existing moisture-response handling, rename the emitted state
+key and layer the resolver on top:
+
+```python
+forecast_val = None
+if moisture_response:
+    forecast_states = self.zone_handler.process_zone_moisture(
+        moisture_response, zone_num)
+    for s in forecast_states:
+        if s["key"] == "moisture":
+            s["key"] = "moistureForecast"
+        forecast_val = s["value"]
+    states.extend(forecast_states)
+
+moisture_val, source = self._resolve_zone_moisture(zone_dev, forecast_val)
+if moisture_val is not None:
+    states.append({"key": "moisture", "value": moisture_val,
+                   "uiValue": f"{moisture_val}%"})
+    self._log_moisture_source_transition(zone_dev, source)
+```
+
+### `plugin.py` — transition-aware logging
+
+To avoid log spam, track the last-logged source on the zone device's
+pluginProps (`lastMoistureSource`). Only log on transitions between
+source categories:
+
+- `whisperer` → `forecast-stale`: **warning** ("Zone X: Whisperer reading
+  stale, falling back to Netro forecast").
+- `forecast-stale` → `whisperer`: **info** ("Zone X: Whisperer reading
+  recovered").
+- `whisperer`/`forecast-*` → `forecast-missing-device` /
+  `forecast-disabled-device`: **warning** once.
+- All others: no log.
+
+### `constants.py`
+
+```python
+WHISPERER_STALENESS_HOURS = 12
+```
+
+### `device_handlers.py`
+
+No changes. `ZoneHandler.process_zone_moisture` still emits keys named
+`"moisture"`; the rename to `"moistureForecast"` happens at the call site
+in `_update_zone_devices`, so the handler's unit tests stay stable.
+
+### `utils.py` (or new helper)
+
+Add `_parse_reading_age_hours(reading_local_time: str) -> float | None`.
+Parses the Whisperer `readingLocalTime` format (check existing Whisperer
+code for the format) and returns hours-since-now in the appropriate
+local timezone. Returns `None` on parse failure → resolver treats as
+stale.
+
+### Edge cases handled
+
+- Paired Whisperer device deleted → `KeyError` → forecast + warning.
+- Paired Whisperer device disabled → forecast + warning.
+- `forecast_val is None` (Netro API error) and Whisperer stale → don't
+  write `moisture` this cycle; previous value stays.
+- `readingLocalTime` unparseable → treated as stale.
+- Zone with a Whisperer paired, then the user manually sets `moisture`
+  via the existing "Override moisture" action — that action still calls
+  Netro's `set_moisture` API, unrelated to this code path. Next poll
+  will re-resolve via the new logic.
+
+## Tests
+
+New module `tests/test_zone_moisture_resolution.py`:
+
+1. Unpaired, forecast available → returns forecast, source="forecast".
+2. Unpaired, forecast None → returns (None, "forecast").
+3. Paired, Whisperer fresh (age < 12h) → returns Whisperer `soilMoisture`.
+4. Paired, Whisperer stale (age > 12h) → returns forecast, warning logged.
+5. Paired, Whisperer stale, second call same state → warning NOT re-logged.
+6. Paired, transitions fresh → stale → warning logged on transition.
+7. Paired, transitions stale → fresh → info log ("sensor recovered").
+8. Paired, Whisperer device deleted → forecast, warning logged once.
+9. Paired, Whisperer device disabled → forecast, warning logged once.
+10. Paired, `readingLocalTime` unparseable → treated as stale.
+11. Paired, forecast also None (Netro down) → returns (None, …), no crash.
+
+Extend `tests/test_plugin_zone_updates.py` (or equivalent):
+
+12. E2E: paired fresh Whisperer → zone states include `moisture` (= Whisperer)
+    AND `moistureForecast` (= Netro).
+13. E2E: unpaired zone → `moisture` == `moistureForecast` == Netro val.
+14. E2E: missing `moisture_response` → `moistureForecast` not written,
+    `moisture` set from Whisperer if fresh-paired.
+
+New test for `getWhispererDevices`:
+
+15. First entry is `("", "(Unpaired — use Netro forecast)")`, followed
+    by sorted Whisperer devices.
+
+Use existing Indigo mock fixtures. Use `freezegun` (or monkeypatched
+`datetime.now`) for the 12h age arithmetic. Target 100% branch coverage
+on the new helper.
+
+## Documentation
+
+1. **`docs/API_NOTES.md` §6** — replace "can be 12–24 hours old" with a
+   clear statement that `/moistures.json` is Netro's **smart-model
+   prediction** (post-irrigation saturation + daily decay), not a
+   sampled sensor value. Can diverge significantly from a paired
+   Whisperer's reading. Reference the new `moistureForecast` state as
+   the way to observe the prediction alongside the resolved value.
+   Note the open empirical question about Netro-side dead-Whisperer
+   behavior.
+
+2. **`README.md`** — small note under the Whisperer section explaining
+   the new per-zone pairing dropdown and the `moisture` vs
+   `moistureForecast` distinction.
+
+## Migration / backwards compat
+
+- Existing zones with no `linkedWhispererDeviceId` prop →
+  `dict.get(..., "")` returns `""` → unpaired path → identical to
+  today's behavior.
+- First poll after upgrade: `moistureForecast` starts populating.
+  `moisture` continues to show forecast until user pairs a Whisperer.
+  No data backfill required.
+- `<UiDisplayStateId>moisture</UiDisplayStateId>` stays — zone tiles
+  keep showing the same "primary" field (now resolved).
+- No pluginProps schema migration — Indigo handles missing keys
+  gracefully via `.get()`.
+
+## Versioning
+
+User-visible feature (new ConfigUI + new state), so **minor** bump of
+`PluginVersion` in `Info.plist`: `YYYY.R.P` → `YYYY.(R+1).0`.
+
+## Acceptance criteria (from issue #54)
+
+- [x] Zone device config has a Whisperer dropdown → Devices.xml +
+      `getWhispererDevices` callback.
+- [x] When paired (and fresh), zone `moisture` state mirrors Whisperer's
+      current reading → `_resolve_zone_moisture`.
+- [x] `moistureForecast` state exposes the `/moistures.json` daily value
+      → new state + call-site key rename.
+- [x] Tests covering paired / unpaired / Whisperer unavailable paths →
+      `tests/test_zone_moisture_resolution.py` + E2E extensions.
+- [x] `API_NOTES.md` updated → §6 rewrite.

--- a/docs/plans/2026-04-23-whisperer-zone-pairing-plan.md
+++ b/docs/plans/2026-04-23-whisperer-zone-pairing-plan.md
@@ -1,0 +1,1357 @@
+# Whisperer ↔ Zone Pairing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add per-zone Whisperer pairing so zone `moisture` reflects the actual sensor reading when a paired Whisperer is fresh (≤12h old), with graceful fallback to Netro's `/moistures.json` forecast.
+
+**Architecture:** Single writer — the zone update loop pulls the paired Whisperer's current state from Indigo's device DB, checks age, and resolves whether `moisture` comes from the sensor or the forecast. The forecast always lands in a new `moistureForecast` state. The Whisperer update loop is unchanged.
+
+**Tech Stack:** Python 3.10+, Indigo Plugin SDK (v3/v4), pytest + pytest-cov, pylint. Tests run against mocked `indigo.*` objects.
+
+**Design doc:** `docs/plans/2026-04-23-whisperer-zone-pairing-design.md` (issue #54)
+
+**Branch:** `feat/whisperer-zone-pairing` (already created off `origin/main`).
+
+**Reference files (cross-cutting):**
+- Plugin module: `Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py`
+- Device definitions: `Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml`
+- Constants: `Netro Sprinklers.indigoPlugin/Contents/Server Plugin/constants.py`
+- Utils: `Netro Sprinklers.indigoPlugin/Contents/Server Plugin/utils.py`
+- Handlers: `Netro Sprinklers.indigoPlugin/Contents/Server Plugin/device_handlers.py`
+- Info.plist: `Netro Sprinklers.indigoPlugin/Contents/Info.plist`
+- Tests conftest: `tests/conftest.py`
+- Existing handler tests: `tests/test_device_handlers.py`
+
+**Conventions:**
+- 120-char lines (enforced by pylint in `pyproject.toml`).
+- Write failing test → minimal implementation → pass → commit, per task.
+- **No squash merges.** Commit each task separately.
+- Version bump happens at the end (single commit, minor bump: user-visible feature).
+- Use `date -u` for any timestamps you reference in commit messages — don't guess.
+
+**Test command (shared):** `pytest tests/ -v` from the repo root. Use `-k` to narrow to a specific test during iteration. Full suite must stay green at every commit point.
+
+**Python interpreter:** use the project's interpreter (honored by pytest). If you need a direct invocation, `python3 -m pytest ...` is fine — the plugin runs on Python 3.10+.
+
+---
+
+## Task 1: Add staleness constant
+
+**Files:**
+- Modify: `Netro Sprinklers.indigoPlugin/Contents/Server Plugin/constants.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/test_constants_whisperer.py`:
+
+```python
+"""Tests for Whisperer-specific constants."""
+import constants
+
+
+def test_whisperer_staleness_hours_defined():
+    """WHISPERER_STALENESS_HOURS should be defined as a positive integer."""
+    assert hasattr(constants, "WHISPERER_STALENESS_HOURS")
+    assert isinstance(constants.WHISPERER_STALENESS_HOURS, int)
+    assert constants.WHISPERER_STALENESS_HOURS > 0
+
+
+def test_whisperer_staleness_hours_value():
+    """WHISPERER_STALENESS_HOURS should be 12 hours (2-12 missed readings at 1-6h cadence)."""
+    assert constants.WHISPERER_STALENESS_HOURS == 12
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_constants_whisperer.py -v`
+Expected: FAIL — `AttributeError: module 'constants' has no attribute 'WHISPERER_STALENESS_HOURS'`.
+
+**Step 3: Write minimal implementation**
+
+Append to `constants.py` (at end of "Default Values" section, after `TOKEN_WARNING_THRESHOLD`):
+
+```python
+WHISPERER_STALENESS_HOURS: Final[int] = 12
+"""Maximum age (hours) for a Whisperer reading to be considered fresh.
+
+Whisperers report every 1-6 hours depending on battery level. 12h = 2-12
+missed readings — tolerates brief API outages but catches a dead battery
+within a day. When a paired Whisperer reading is older than this, the
+zone falls back to Netro's /moistures.json forecast.
+"""
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_constants_whisperer.py -v`
+Expected: PASS (2 tests).
+
+Also run the full suite to confirm no regression: `pytest tests/ -v`
+Expected: all existing tests still pass.
+
+**Step 5: Commit**
+
+```bash
+git add "Netro Sprinklers.indigoPlugin/Contents/Server Plugin/constants.py" tests/test_constants_whisperer.py
+git commit -m "feat(netro): add WHISPERER_STALENESS_HOURS constant (#54)"
+```
+
+---
+
+## Task 2: Add reading-age parse utility
+
+**Context:** Whisperer's `readingTime` state holds the raw `time` field from the API. V1 = epoch millis (e.g. `1234567890000`). V2 = ISO-8601 string (e.g. `"2026-04-07T10:00:00"`). Helper must accept either and return age-in-hours as float, `None` on unparseable input.
+
+**Files:**
+- Modify: `Netro Sprinklers.indigoPlugin/Contents/Server Plugin/utils.py`
+- Create: `tests/test_reading_age.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/test_reading_age.py`:
+
+```python
+"""Tests for parse_reading_age_hours utility."""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+import utils
+
+
+class TestParseReadingAgeHours:
+    """Test utils.parse_reading_age_hours across supported input formats."""
+
+    @pytest.fixture
+    def fixed_now(self):
+        """Anchor "now" to a known UTC datetime for deterministic age math."""
+        return datetime(2026, 4, 23, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_v2_iso_string_fresh(self, fixed_now):
+        """ISO-8601 string 3h old → ~3.0 hours."""
+        three_hours_ago = (fixed_now - timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%S")
+        with patch("utils._now_utc", return_value=fixed_now):
+            age = utils.parse_reading_age_hours(three_hours_ago)
+        assert age is not None
+        assert 2.9 <= age <= 3.1
+
+    def test_v2_iso_string_with_timezone(self, fixed_now):
+        """ISO-8601 string with Z suffix should be treated as UTC."""
+        three_hours_ago = (fixed_now - timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with patch("utils._now_utc", return_value=fixed_now):
+            age = utils.parse_reading_age_hours(three_hours_ago)
+        assert age is not None
+        assert 2.9 <= age <= 3.1
+
+    def test_v1_epoch_millis_fresh(self, fixed_now):
+        """V1 epoch millis 3h old → ~3.0 hours."""
+        epoch_ms = int((fixed_now - timedelta(hours=3)).timestamp() * 1000)
+        with patch("utils._now_utc", return_value=fixed_now):
+            age = utils.parse_reading_age_hours(epoch_ms)
+        assert age is not None
+        assert 2.9 <= age <= 3.1
+
+    def test_v1_epoch_millis_as_string(self, fixed_now):
+        """Epoch millis passed as a string should still parse."""
+        epoch_ms_str = str(int((fixed_now - timedelta(hours=3)).timestamp() * 1000))
+        with patch("utils._now_utc", return_value=fixed_now):
+            age = utils.parse_reading_age_hours(epoch_ms_str)
+        assert age is not None
+        assert 2.9 <= age <= 3.1
+
+    def test_stale_reading(self, fixed_now):
+        """24h-old reading → 24.0 hours (above threshold)."""
+        one_day_ago = (fixed_now - timedelta(hours=24)).strftime("%Y-%m-%dT%H:%M:%S")
+        with patch("utils._now_utc", return_value=fixed_now):
+            age = utils.parse_reading_age_hours(one_day_ago)
+        assert age is not None
+        assert 23.9 <= age <= 24.1
+
+    def test_unparseable_string_returns_none(self):
+        """Garbage input returns None, does not raise."""
+        assert utils.parse_reading_age_hours("not-a-timestamp") is None
+        assert utils.parse_reading_age_hours("unknown") is None
+
+    def test_empty_string_returns_none(self):
+        """Empty string returns None."""
+        assert utils.parse_reading_age_hours("") is None
+
+    def test_none_input_returns_none(self):
+        """None input returns None."""
+        assert utils.parse_reading_age_hours(None) is None
+
+    def test_negative_age_clamped_to_zero(self, fixed_now):
+        """Future timestamp (clock skew) returns 0.0, never negative."""
+        future = (fixed_now + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
+        with patch("utils._now_utc", return_value=fixed_now):
+            age = utils.parse_reading_age_hours(future)
+        assert age == 0.0
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_reading_age.py -v`
+Expected: FAIL — `AttributeError: module 'utils' has no attribute 'parse_reading_age_hours'`.
+
+**Step 3: Write minimal implementation**
+
+Add to `utils.py` (new section at end, above `get_key_from_dict`):
+
+```python
+from datetime import datetime, timezone
+from typing import Optional, Union
+
+
+def _now_utc() -> datetime:
+    """Return current time as a timezone-aware UTC datetime.
+
+    Indirected through a module-level function so tests can patch it
+    deterministically without depending on freezegun or similar.
+    """
+    return datetime.now(tz=timezone.utc)
+
+
+def parse_reading_age_hours(
+    reading_time: Union[str, int, float, None]
+) -> Optional[float]:
+    """Compute age (hours) of a Whisperer reading timestamp.
+
+    Accepts both API v1 and v2 timestamp formats emitted by
+    ``WhispererHandler.process_sensor_data``:
+
+    - **V1 (epoch millis)**: e.g. ``1234567890000`` (int or numeric string)
+    - **V2 (ISO 8601)**: e.g. ``"2026-04-07T10:00:00"`` or ``"...Z"``
+
+    Args:
+        reading_time: Value from the Whisperer ``readingTime`` state.
+
+    Returns:
+        Age in hours (non-negative float) if parseable, ``None`` otherwise.
+        Returns ``0.0`` when the reading is in the future (clock skew).
+
+    Note:
+        V2 ISO strings without an explicit timezone are assumed to be UTC.
+        Netro's ``time`` field is the sensor's UTC timestamp; ``local_time``
+        is the pre-formatted local variant. We intentionally use the UTC
+        form for age math to avoid DST/tz drift.
+    """
+    if reading_time is None or reading_time == "":
+        return None
+
+    now = _now_utc()
+
+    # Try ISO 8601 first (covers v2 and any pre-formatted strings).
+    if isinstance(reading_time, str):
+        candidate = reading_time.rstrip("Z").strip()
+        try:
+            parsed = datetime.fromisoformat(candidate)
+        except ValueError:
+            parsed = None
+        else:
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            delta = (now - parsed).total_seconds() / 3600.0
+            return max(0.0, delta)
+
+        # Fall through: maybe it's a stringified epoch millis.
+        try:
+            reading_time = int(candidate)
+        except (TypeError, ValueError):
+            return None
+
+    # Epoch millis (int or float from numeric-string fallthrough above).
+    if isinstance(reading_time, (int, float)):
+        try:
+            seconds = float(reading_time) / 1000.0
+            parsed = datetime.fromtimestamp(seconds, tz=timezone.utc)
+        except (OSError, OverflowError, ValueError):
+            return None
+        delta = (now - parsed).total_seconds() / 3600.0
+        return max(0.0, delta)
+
+    return None
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_reading_age.py -v`
+Expected: PASS (9 tests).
+
+Full suite: `pytest tests/ -v`
+Expected: all existing tests still pass.
+
+**Step 5: Commit**
+
+```bash
+git add "Netro Sprinklers.indigoPlugin/Contents/Server Plugin/utils.py" tests/test_reading_age.py
+git commit -m "feat(netro): add parse_reading_age_hours for v1 epoch + v2 ISO (#54)"
+```
+
+---
+
+## Task 3: Add `moistureForecast` state to Devices.xml
+
+**Files:**
+- Modify: `Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml`
+
+**Note:** `Devices.xml` is not unit-testable in isolation (it's consumed by the Indigo server at runtime). Rely on the XML validity check and downstream plugin tests for coverage.
+
+**Step 1: Verify current XML is valid, then edit**
+
+Run: `python3 -c "import xml.etree.ElementTree as ET; ET.parse('Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml'); print('OK')"`
+Expected: `OK`.
+
+**Step 2: Add the new state**
+
+In `Devices.xml`, inside `<Device type="custom" id="zone">` → `<States>`, immediately after the existing `<State id="moisture">` block (around line 312), insert:
+
+```xml
+            <State id="moistureForecast">
+                <ValueType>Integer</ValueType>
+                <TriggerLabel>Moisture Forecast (%)</TriggerLabel>
+                <ControlPageLabel>Moisture Forecast (%)</ControlPageLabel>
+            </State>
+```
+
+(Keep `<UiDisplayStateId>moisture</UiDisplayStateId>` unchanged at the bottom of the zone device block.)
+
+**Step 3: Verify XML still parses**
+
+Run: `python3 -c "import xml.etree.ElementTree as ET; t = ET.parse('Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml'); zone = [d for d in t.findall('.//Device') if d.get('id') == 'zone'][0]; states = [s.get('id') for s in zone.findall('.//State')]; print('moisture' in states and 'moistureForecast' in states)"`
+Expected: `True`.
+
+**Step 4: Commit**
+
+```bash
+git add "Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml"
+git commit -m "feat(netro): add moistureForecast state to zone device (#54)"
+```
+
+---
+
+## Task 4: Add zone-device ConfigUI for Whisperer pairing (XML only)
+
+**Files:**
+- Modify: `Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml`
+
+**Step 1: Add ConfigUI fields**
+
+In `Devices.xml`, inside `<Device type="custom" id="zone">` → `<ConfigUI>`, append **after** the existing hidden `zoneNumber` field (around line 305):
+
+```xml
+        <Field id="sep_sensor" type="separator"/>
+        <Field id="sensorLabel" type="label">
+            <Label>Soil Moisture Source</Label>
+        </Field>
+        <Field id="linkedWhispererDeviceId" type="menu" defaultValue="">
+            <Label>Paired Whisperer:</Label>
+            <List class="self" method="getWhispererDevices" dynamicReload="true"/>
+        </Field>
+        <Field id="sensorHelp" type="label" fontSize="small" fontColor="darkgray" alignWithControl="true">
+            <Label>When paired, the zone's moisture state mirrors the Whisperer's soil reading (if fresh within 12 hours). Otherwise, it shows Netro's daily forecast. The forecast is always available separately as the "Moisture Forecast" state.</Label>
+        </Field>
+```
+
+**Step 2: Verify XML still parses and the callback reference is present**
+
+Run: `python3 -c "import xml.etree.ElementTree as ET; t = ET.parse('Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml'); zone = [d for d in t.findall('.//Device') if d.get('id') == 'zone'][0]; fields = [f.get('id') for f in zone.findall('.//ConfigUI/Field')]; print('linkedWhispererDeviceId' in fields)"`
+Expected: `True`.
+
+**Step 3: Commit**
+
+```bash
+git add "Netro Sprinklers.indigoPlugin/Contents/Server Plugin/Devices.xml"
+git commit -m "feat(netro): add Whisperer pairing dropdown to zone ConfigUI (#54)"
+```
+
+---
+
+## Task 5: Implement `getWhispererDevices` callback
+
+**Context:** Indigo calls this when the zone ConfigUI dropdown is opened. Returns a list of `(value, label)` tuples. First entry is the "unpaired" sentinel (empty string value).
+
+**Files:**
+- Modify: `Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py`
+- Create: `tests/test_whisperer_pairing_callback.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/test_whisperer_pairing_callback.py`:
+
+```python
+"""Tests for Plugin.getWhispererDevices ConfigUI callback."""
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_indigo(monkeypatch):
+    """Install a minimal `indigo` module into sys.modules for plugin import."""
+    indigo = MagicMock()
+    indigo.devices.iter = MagicMock(return_value=iter([]))
+    monkeypatch.setitem(sys.modules, "indigo", indigo)
+    return indigo
+
+
+def _fake_device(dev_id, name, type_id="Whisperer"):
+    return SimpleNamespace(id=dev_id, name=name, deviceTypeId=type_id)
+
+
+def test_returns_unpaired_sentinel_when_no_whisperers(mock_indigo):
+    """With zero Whisperers installed, returns only the unpaired option."""
+    mock_indigo.devices.iter.return_value = iter([])
+    # Import after mock is installed.
+    from plugin import Plugin  # noqa: WPS433
+    plugin = Plugin.__new__(Plugin)  # skip __init__
+    result = plugin.getWhispererDevices()
+    assert result[0] == ("", "(Unpaired — use Netro forecast)")
+    assert len(result) == 1
+
+
+def test_returns_whisperers_sorted_by_name(mock_indigo):
+    """Whisperers are appended, sorted case-insensitively by name."""
+    devs = [
+        _fake_device(101, "Zebra"),
+        _fake_device(102, "apple"),
+        _fake_device(103, "Mango"),
+        _fake_device(104, "Sprite 8-zone", type_id="Sprite"),  # not Whisperer
+    ]
+    mock_indigo.devices.iter.return_value = iter(devs)
+    from plugin import Plugin  # noqa: WPS433
+    plugin = Plugin.__new__(Plugin)
+    result = plugin.getWhispererDevices()
+    assert result[0] == ("", "(Unpaired — use Netro forecast)")
+    assert result[1:] == [("102", "apple"), ("103", "Mango"), ("101", "Zebra")]
+
+
+def test_ignores_non_whisperer_devices(mock_indigo):
+    """Sprite/Pixie/Spark controllers and zones are excluded."""
+    devs = [
+        _fake_device(1, "Sprite 8", type_id="Sprite"),
+        _fake_device(2, "Pixie 12", type_id="Pixie"),
+        _fake_device(3, "Zone A", type_id="zone"),
+        _fake_device(4, "Garden Whisperer", type_id="Whisperer"),
+    ]
+    mock_indigo.devices.iter.return_value = iter(devs)
+    from plugin import Plugin  # noqa: WPS433
+    plugin = Plugin.__new__(Plugin)
+    result = plugin.getWhispererDevices()
+    whisperer_ids = [r[0] for r in result[1:]]
+    assert whisperer_ids == ["4"]
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_whisperer_pairing_callback.py -v`
+Expected: FAIL — `AttributeError: 'Plugin' object has no attribute 'getWhispererDevices'`.
+
+**Step 3: Write minimal implementation**
+
+In `plugin.py`, add the method to the `Plugin` class. Place it near other ConfigUI callbacks — search for an existing `def ...(self, filter="", valuesDict=None, typeId="", targetId=0)` signature to find the right neighbourhood; if none exists, place it immediately before `def _update_zone_devices` (around the helper-methods section):
+
+```python
+def getWhispererDevices(self, filter="", valuesDict=None, typeId="", targetId=0):
+    """Populate the `linkedWhispererDeviceId` dropdown on zone ConfigUI.
+
+    Returns a list of (value, label) tuples:
+      - First entry: ("", "(Unpaired — use Netro forecast)") sentinel.
+      - Remaining entries: this plugin's Whisperer devices, sorted
+        case-insensitively by name. Value is the Indigo device ID as a
+        string; label is the device name.
+
+    Called by Indigo when the ConfigUI is opened / reloaded.
+    """
+    options = [("", "(Unpaired — use Netro forecast)")]
+    whisperers = sorted(
+        (d for d in indigo.devices.iter(filter="self")
+         if d.deviceTypeId == "Whisperer"),
+        key=lambda d: d.name.lower(),
+    )
+    options.extend((str(d.id), d.name) for d in whisperers)
+    return options
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_whisperer_pairing_callback.py -v`
+Expected: PASS (3 tests).
+
+Full suite: `pytest tests/ -v`
+Expected: green.
+
+**Step 5: Commit**
+
+```bash
+git add "Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py" tests/test_whisperer_pairing_callback.py
+git commit -m "feat(netro): add getWhispererDevices ConfigUI callback (#54)"
+```
+
+---
+
+## Task 6: Implement `_resolve_zone_moisture` helper
+
+**Context:** Pure-ish function — takes a zone device and a forecast value, returns `(resolved_value, source_tag)`. No logging here (that's task 7). No state writes here (call site does that in task 8).
+
+Source tags:
+- `"forecast"` — unpaired.
+- `"whisperer"` — paired, fresh reading.
+- `"forecast-stale"` — paired, reading too old (> 12h) or no reading.
+- `"forecast-missing-device"` — paired id no longer resolves.
+- `"forecast-disabled-device"` — paired device exists but is disabled.
+
+**Files:**
+- Modify: `Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py`
+- Create: `tests/test_zone_moisture_resolution.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/test_zone_moisture_resolution.py`:
+
+```python
+"""Tests for Plugin._resolve_zone_moisture."""
+import sys
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_indigo(monkeypatch):
+    indigo = MagicMock()
+    # `indigo.devices[id]` lookup; tests install a side_effect dict.
+    indigo._devices_by_id = {}
+
+    def _getitem(dev_id):
+        if dev_id not in indigo._devices_by_id:
+            raise KeyError(dev_id)
+        return indigo._devices_by_id[dev_id]
+
+    indigo.devices.__getitem__.side_effect = _getitem
+    monkeypatch.setitem(sys.modules, "indigo", indigo)
+    return indigo
+
+
+@pytest.fixture
+def plugin_instance(mock_indigo):
+    from plugin import Plugin  # noqa: WPS433
+    return Plugin.__new__(Plugin)
+
+
+def _fake_whisperer(enabled=True, soil=30, reading_time="2026-04-23T10:00:00"):
+    return SimpleNamespace(
+        enabled=enabled,
+        states={"soilMoisture": soil, "readingTime": reading_time},
+    )
+
+
+def _fake_zone(linked_id=""):
+    return SimpleNamespace(pluginProps={"linkedWhispererDeviceId": linked_id})
+
+
+FROZEN_NOW = datetime(2026, 4, 23, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# --- Unpaired paths ---
+
+def test_unpaired_returns_forecast(plugin_instance):
+    zone = _fake_zone(linked_id="")
+    val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=55)
+    assert (val, src) == (55, "forecast")
+
+
+def test_unpaired_forecast_none(plugin_instance):
+    zone = _fake_zone(linked_id="")
+    val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=None)
+    assert (val, src) == (None, "forecast")
+
+
+# --- Paired, fresh ---
+
+def test_paired_fresh_returns_whisperer(plugin_instance, mock_indigo):
+    whisperer = _fake_whisperer(
+        soil=24,
+        reading_time=(FROZEN_NOW - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S"),
+    )
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (24, "whisperer")
+
+
+# --- Paired, stale ---
+
+def test_paired_stale_returns_forecast(plugin_instance, mock_indigo):
+    whisperer = _fake_whisperer(
+        soil=24,
+        reading_time=(FROZEN_NOW - timedelta(hours=20)).strftime("%Y-%m-%dT%H:%M:%S"),
+    )
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-stale")
+
+
+def test_paired_stale_forecast_also_none(plugin_instance, mock_indigo):
+    whisperer = _fake_whisperer(
+        soil=24,
+        reading_time=(FROZEN_NOW - timedelta(hours=20)).strftime("%Y-%m-%dT%H:%M:%S"),
+    )
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=None)
+    assert (val, src) == (None, "forecast-stale")
+
+
+# --- Paired, Whisperer missing ---
+
+def test_paired_device_deleted(plugin_instance, mock_indigo):
+    zone = _fake_zone(linked_id="999")  # 999 not in _devices_by_id
+    val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-missing-device")
+
+
+def test_paired_invalid_id(plugin_instance):
+    zone = _fake_zone(linked_id="not-an-int")
+    val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-missing-device")
+
+
+# --- Paired, Whisperer disabled ---
+
+def test_paired_device_disabled(plugin_instance, mock_indigo):
+    whisperer = _fake_whisperer(enabled=False, soil=24)
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-disabled-device")
+
+
+# --- Paired, unparseable time ---
+
+def test_paired_unparseable_reading_time(plugin_instance, mock_indigo):
+    whisperer = _fake_whisperer(reading_time="unknown")
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-stale")
+
+
+# --- Paired, no soilMoisture state ---
+
+def test_paired_no_soil_state(plugin_instance, mock_indigo):
+    whisperer = SimpleNamespace(
+        enabled=True,
+        states={"readingTime": "2026-04-23T10:00:00"},  # soilMoisture missing
+    )
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-stale")
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_zone_moisture_resolution.py -v`
+Expected: FAIL — `AttributeError: 'Plugin' object has no attribute '_resolve_zone_moisture'`.
+
+**Step 3: Write minimal implementation**
+
+In `plugin.py`, add the method to the `Plugin` class, immediately after `getWhispererDevices`:
+
+```python
+def _resolve_zone_moisture(self, zone_dev, forecast_val):
+    """Resolve the "moisture" state value for a zone device.
+
+    Pure function (no state writes, no logging). Returns a
+    ``(value, source_tag)`` pair where source_tag is one of:
+
+    - ``"forecast"``: zone has no paired Whisperer; returns forecast_val.
+    - ``"whisperer"``: paired Whisperer exists, is enabled, has a fresh
+      (≤ WHISPERER_STALENESS_HOURS old) ``soilMoisture`` reading.
+    - ``"forecast-stale"``: paired but reading is missing, too old, or
+      ``readingTime`` is unparseable.
+    - ``"forecast-missing-device"``: paired device id does not resolve
+      to an Indigo device (deleted or invalid id).
+    - ``"forecast-disabled-device"``: paired device exists but is
+      disabled in Indigo.
+
+    ``value`` may be ``None`` if forecast_val is None and no Whisperer
+    value is available; the caller should skip writing ``moisture`` in
+    that case.
+    """
+    from constants import WHISPERER_STALENESS_HOURS  # noqa: WPS433
+    from utils import parse_reading_age_hours  # noqa: WPS433
+
+    linked_id = zone_dev.pluginProps.get("linkedWhispererDeviceId", "")
+    if not linked_id:
+        return forecast_val, "forecast"
+
+    try:
+        whisperer = indigo.devices[int(linked_id)]
+    except (KeyError, ValueError):
+        return forecast_val, "forecast-missing-device"
+
+    if not whisperer.enabled:
+        return forecast_val, "forecast-disabled-device"
+
+    soil = whisperer.states.get("soilMoisture")
+    reading_time = whisperer.states.get("readingTime", "")
+    age_hours = parse_reading_age_hours(reading_time)
+    if soil is None or age_hours is None or age_hours > WHISPERER_STALENESS_HOURS:
+        return forecast_val, "forecast-stale"
+
+    return int(soil), "whisperer"
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_zone_moisture_resolution.py -v`
+Expected: PASS (10 tests).
+
+Full suite: `pytest tests/ -v`
+Expected: green.
+
+**Step 5: Commit**
+
+```bash
+git add "Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py" tests/test_zone_moisture_resolution.py
+git commit -m "feat(netro): add _resolve_zone_moisture helper (#54)"
+```
+
+---
+
+## Task 7: Implement `_log_moisture_source_transition`
+
+**Context:** Transition-aware logger — writes the zone's `lastMoistureSource` into `pluginProps` so we only log when the source category changes. Prevents log spam on steady-state operation.
+
+Logging rules (triggered on transition only):
+- `"forecast"` → `"whisperer"`: info ("paired Whisperer reading active").
+- `"whisperer"` → `"forecast-stale"`: warning ("Whisperer reading stale, falling back to forecast").
+- `"forecast-stale"` → `"whisperer"`: info ("Whisperer reading recovered").
+- Any → `"forecast-missing-device"`: warning ("paired Whisperer device no longer exists").
+- Any → `"forecast-disabled-device"`: warning ("paired Whisperer device is disabled").
+- All other transitions: silent (e.g. `forecast` → `forecast-stale` shouldn't happen, but if it does, silent is safe).
+
+**Files:**
+- Modify: `Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py`
+- Create: `tests/test_moisture_source_logging.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/test_moisture_source_logging.py`:
+
+```python
+"""Tests for Plugin._log_moisture_source_transition."""
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_indigo(monkeypatch):
+    indigo = MagicMock()
+    monkeypatch.setitem(sys.modules, "indigo", indigo)
+    return indigo
+
+
+@pytest.fixture
+def plugin_instance(mock_indigo):
+    from plugin import Plugin  # noqa: WPS433
+    plugin = Plugin.__new__(Plugin)
+    plugin.logger = MagicMock()
+    return plugin
+
+
+def _zone(last_source=None, name="Test Zone"):
+    """A fake zone with a mutable pluginProps dict and a replacePluginPropsOnServer stub."""
+    props = {}
+    if last_source is not None:
+        props["lastMoistureSource"] = last_source
+    replaced = []
+
+    def _replace(new_props):
+        replaced.append(dict(new_props))
+
+    return SimpleNamespace(
+        name=name,
+        pluginProps=props,
+        replacePluginPropsOnServer=_replace,
+        _replaced=replaced,
+    )
+
+
+def test_no_log_when_source_unchanged(plugin_instance):
+    zone = _zone(last_source="whisperer")
+    plugin_instance._log_moisture_source_transition(zone, "whisperer")
+    plugin_instance.logger.warning.assert_not_called()
+    plugin_instance.logger.info.assert_not_called()
+    # pluginProps still reflect the (unchanged) value.
+    assert zone.pluginProps.get("lastMoistureSource") == "whisperer"
+
+
+def test_log_info_on_forecast_to_whisperer(plugin_instance):
+    zone = _zone(last_source="forecast")
+    plugin_instance._log_moisture_source_transition(zone, "whisperer")
+    plugin_instance.logger.info.assert_called_once()
+    assert "Whisperer reading" in plugin_instance.logger.info.call_args[0][0]
+    assert zone.pluginProps["lastMoistureSource"] == "whisperer"
+
+
+def test_log_warning_on_whisperer_to_stale(plugin_instance):
+    zone = _zone(last_source="whisperer")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-stale")
+    plugin_instance.logger.warning.assert_called_once()
+    msg = plugin_instance.logger.warning.call_args[0][0]
+    assert "stale" in msg.lower()
+    assert "forecast" in msg.lower()
+
+
+def test_log_info_on_stale_to_whisperer(plugin_instance):
+    zone = _zone(last_source="forecast-stale")
+    plugin_instance._log_moisture_source_transition(zone, "whisperer")
+    plugin_instance.logger.info.assert_called_once()
+    assert "recovered" in plugin_instance.logger.info.call_args[0][0].lower()
+
+
+def test_log_warning_on_missing_device(plugin_instance):
+    zone = _zone(last_source="whisperer")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-missing-device")
+    plugin_instance.logger.warning.assert_called_once()
+    assert "no longer" in plugin_instance.logger.warning.call_args[0][0].lower()
+
+
+def test_log_warning_on_disabled_device(plugin_instance):
+    zone = _zone(last_source="whisperer")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-disabled-device")
+    plugin_instance.logger.warning.assert_called_once()
+    assert "disabled" in plugin_instance.logger.warning.call_args[0][0].lower()
+
+
+def test_no_log_when_cold_start_forecast(plugin_instance):
+    """Fresh install, first-ever poll on an unpaired zone → silent (no transition)."""
+    zone = _zone(last_source=None)
+    plugin_instance._log_moisture_source_transition(zone, "forecast")
+    plugin_instance.logger.warning.assert_not_called()
+    plugin_instance.logger.info.assert_not_called()
+    assert zone.pluginProps["lastMoistureSource"] == "forecast"
+
+
+def test_repeated_warning_suppressed(plugin_instance):
+    """Same stale source across two polls logs only once."""
+    zone = _zone(last_source="whisperer")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-stale")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-stale")
+    assert plugin_instance.logger.warning.call_count == 1
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_moisture_source_logging.py -v`
+Expected: FAIL on all tests — method not defined.
+
+**Step 3: Write minimal implementation**
+
+In `plugin.py`, add immediately after `_resolve_zone_moisture`:
+
+```python
+def _log_moisture_source_transition(self, zone_dev, new_source):
+    """Log a transition between moisture-source categories for a zone.
+
+    Persists the current source in ``zone_dev.pluginProps['lastMoistureSource']``
+    and only emits a log line when the category changes, to avoid spam.
+    The first-ever call on a fresh install is silent (no prior state).
+
+    Args:
+        zone_dev: Indigo zone device.
+        new_source: One of the source tags returned by
+            ``_resolve_zone_moisture``.
+    """
+    prev = zone_dev.pluginProps.get("lastMoistureSource")
+    if prev == new_source:
+        return
+
+    transition = (prev, new_source)
+    if prev is not None:
+        if transition == ("forecast", "whisperer") or transition == ("forecast-stale", "whisperer"):
+            if prev == "forecast-stale":
+                self.logger.info(
+                    f"Zone '{zone_dev.name}': Whisperer reading recovered — "
+                    f"moisture now tracking paired sensor."
+                )
+            else:
+                self.logger.info(
+                    f"Zone '{zone_dev.name}': paired Whisperer reading active — "
+                    f"moisture now tracking sensor."
+                )
+        elif new_source == "forecast-stale":
+            self.logger.warning(
+                f"Zone '{zone_dev.name}': paired Whisperer reading stale "
+                f"(>12h old) — falling back to Netro forecast."
+            )
+        elif new_source == "forecast-missing-device":
+            self.logger.warning(
+                f"Zone '{zone_dev.name}': paired Whisperer device no longer "
+                f"exists — falling back to Netro forecast."
+            )
+        elif new_source == "forecast-disabled-device":
+            self.logger.warning(
+                f"Zone '{zone_dev.name}': paired Whisperer device is disabled "
+                f"— falling back to Netro forecast."
+            )
+
+    # Persist the new source so the next poll can detect the next transition.
+    new_props = dict(zone_dev.pluginProps)
+    new_props["lastMoistureSource"] = new_source
+    zone_dev.pluginProps = new_props  # keep test-side dict in sync
+    zone_dev.replacePluginPropsOnServer(new_props)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_moisture_source_logging.py -v`
+Expected: PASS (8 tests).
+
+Full suite: `pytest tests/ -v`
+Expected: green.
+
+**Step 5: Commit**
+
+```bash
+git add "Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py" tests/test_moisture_source_logging.py
+git commit -m "feat(netro): add transition-aware moisture source logging (#54)"
+```
+
+---
+
+## Task 8: Wire resolver + logger into `_update_zone_devices`
+
+**Context:** Now patch the existing zone-update loop to:
+1. Rename the key emitted by `process_zone_moisture` from `"moisture"` to `"moistureForecast"`.
+2. Call `_resolve_zone_moisture` to decide the `"moisture"` value.
+3. Call `_log_moisture_source_transition`.
+
+**Files:**
+- Modify: `Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py` (in `_update_zone_devices` around line 690, specifically the `if moisture_response:` block near line 726).
+- Create: `tests/test_update_zone_devices_integration.py`
+
+**Step 1: Read the current implementation**
+
+First, open `plugin.py` and locate `_update_zone_devices`. Find the block that processes `moisture_response` (grep: `process_zone_moisture`). It currently emits states keyed `"moisture"` directly from `ZoneHandler.process_zone_moisture`. Note the exact surrounding code so your edit matches context.
+
+**Step 2: Write the failing integration test**
+
+Create `tests/test_update_zone_devices_integration.py`:
+
+```python
+"""Integration tests for Plugin._update_zone_devices moisture resolution.
+
+These tests verify the call-site rewiring:
+  - moistureForecast gets the /moistures.json value.
+  - moisture gets the resolved value (Whisperer if fresh + paired, else forecast).
+  - Source transitions are logged.
+"""
+import sys
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+FROZEN_NOW = datetime(2026, 4, 23, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def mock_indigo(monkeypatch):
+    indigo = MagicMock()
+    indigo._devices_by_id = {}
+    indigo.devices.__getitem__.side_effect = lambda k: indigo._devices_by_id[k]
+    monkeypatch.setitem(sys.modules, "indigo", indigo)
+    return indigo
+
+
+@pytest.fixture
+def plugin_instance(mock_indigo):
+    from plugin import Plugin  # noqa: WPS433
+    plugin = Plugin.__new__(Plugin)
+    plugin.logger = MagicMock()
+    # ZoneHandler is instantiated in __init__; bypass it by attaching a stub.
+    from device_handlers import ZoneHandler
+    plugin.zone_handler = ZoneHandler(logger=MagicMock())
+    return plugin
+
+
+def _zone_dev(zone_num=1, linked_id="", name="Front Lawn"):
+    replaced_states = []
+    replaced_props = []
+
+    def _update_states(states):
+        replaced_states.extend(states)
+
+    def _replace_props(props):
+        replaced_props.append(dict(props))
+
+    dev = SimpleNamespace(
+        name=name,
+        pluginProps={"zoneNumber": str(zone_num), "linkedWhispererDeviceId": linked_id},
+        enabled=True,
+        states={},
+        updateStatesOnServer=_update_states,
+        replacePluginPropsOnServer=_replace_props,
+        _replaced_states=replaced_states,
+        _replaced_props=replaced_props,
+    )
+    return dev
+
+
+def _whisperer(soil=24, hours_old=2):
+    return SimpleNamespace(
+        enabled=True,
+        states={
+            "soilMoisture": soil,
+            "readingTime": (FROZEN_NOW - timedelta(hours=hours_old)).strftime("%Y-%m-%dT%H:%M:%S"),
+        },
+    )
+
+
+def _moistures_response(zone_num, forecast_val):
+    return {
+        "status": "OK",
+        "data": {
+            "moistures": [
+                {"id": 1, "zone": zone_num, "date": "2026-04-23", "moisture": forecast_val},
+            ],
+        },
+    }
+
+
+def _device_data():
+    return {"zones": []}  # minimum shape; _update_zone_devices iterates zone_devs, not zones
+
+
+def test_paired_fresh_writes_sensor_to_moisture_and_forecast_to_moistureForecast(
+    plugin_instance, mock_indigo
+):
+    zone = _zone_dev(zone_num=1, linked_id="999")
+    mock_indigo._devices_by_id[999] = _whisperer(soil=24, hours_old=2)
+    plugin_instance._get_zone_devices = lambda parent_id: {1: zone}
+    parent = SimpleNamespace(id=42, name="Sprite")
+
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        plugin_instance._update_zone_devices(
+            parent, _device_data(),
+            schedule_response=None,
+            moisture_response=_moistures_response(1, forecast_val=89),
+            api_version="1",
+        )
+
+    keys = {s["key"]: s["value"] for s in zone._replaced_states}
+    assert keys["moisture"] == 24
+    assert keys["moistureForecast"] == 89
+
+
+def test_unpaired_zone_mirrors_forecast_to_both(plugin_instance, mock_indigo):
+    zone = _zone_dev(zone_num=1, linked_id="")
+    plugin_instance._get_zone_devices = lambda parent_id: {1: zone}
+    parent = SimpleNamespace(id=42, name="Sprite")
+
+    plugin_instance._update_zone_devices(
+        parent, _device_data(),
+        schedule_response=None,
+        moisture_response=_moistures_response(1, forecast_val=55),
+        api_version="1",
+    )
+
+    keys = {s["key"]: s["value"] for s in zone._replaced_states}
+    assert keys["moisture"] == 55
+    assert keys["moistureForecast"] == 55
+
+
+def test_missing_moisture_response_skips_both_writes(plugin_instance, mock_indigo):
+    zone = _zone_dev(zone_num=1, linked_id="")
+    plugin_instance._get_zone_devices = lambda parent_id: {1: zone}
+    parent = SimpleNamespace(id=42, name="Sprite")
+
+    plugin_instance._update_zone_devices(
+        parent, _device_data(),
+        schedule_response=None,
+        moisture_response=None,
+        api_version="1",
+    )
+
+    keys = {s["key"]: s.get("value") for s in zone._replaced_states}
+    # When paired=no and forecast missing, we skip writing moisture.
+    assert "moisture" not in keys
+    assert "moistureForecast" not in keys
+
+
+def test_missing_forecast_but_paired_fresh_writes_sensor(plugin_instance, mock_indigo):
+    zone = _zone_dev(zone_num=1, linked_id="999")
+    mock_indigo._devices_by_id[999] = _whisperer(soil=24, hours_old=2)
+    plugin_instance._get_zone_devices = lambda parent_id: {1: zone}
+    parent = SimpleNamespace(id=42, name="Sprite")
+
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        plugin_instance._update_zone_devices(
+            parent, _device_data(),
+            schedule_response=None,
+            moisture_response=None,
+            api_version="1",
+        )
+
+    keys = {s["key"]: s["value"] for s in zone._replaced_states}
+    assert keys["moisture"] == 24
+    # No moistureForecast write when moisture_response is None.
+    assert "moistureForecast" not in keys
+```
+
+**Step 3: Run test to verify it fails**
+
+Run: `pytest tests/test_update_zone_devices_integration.py -v`
+Expected: FAIL on `test_paired_fresh_...` (moisture still 89 or moistureForecast missing) — precise failure depends on current state of the code but tests will not pass.
+
+**Step 4: Modify `_update_zone_devices`**
+
+Locate the block in `_update_zone_devices` that currently looks roughly like:
+
+```python
+if moisture_response:
+    try:
+        states.extend(
+            self.zone_handler.process_zone_moisture(moisture_response, zone_num)
+        )
+    except Exception:
+        ...
+```
+
+Replace with:
+
+```python
+forecast_val = None
+if moisture_response:
+    try:
+        forecast_states = self.zone_handler.process_zone_moisture(
+            moisture_response, zone_num
+        )
+        for entry in forecast_states:
+            if entry.get("key") == "moisture":
+                entry["key"] = "moistureForecast"
+                forecast_val = entry.get("value")
+        states.extend(forecast_states)
+    except Exception:
+        self.logger.exception(
+            f"Error processing moisture for zone {zone_num} on '{zone_dev.name}'"
+        )
+
+moisture_val, source = self._resolve_zone_moisture(zone_dev, forecast_val)
+if moisture_val is not None:
+    states.append({"key": "moisture", "value": moisture_val,
+                   "uiValue": f"{moisture_val}%"})
+self._log_moisture_source_transition(zone_dev, source)
+```
+
+**Important:** if the existing block has a different surrounding context (e.g. a wider try/except), preserve its error-handling shape — only adjust the key rename and inject the resolver call. Read the surrounding ~15 lines before editing.
+
+**Step 5: Run test to verify it passes**
+
+Run: `pytest tests/test_update_zone_devices_integration.py -v`
+Expected: PASS (4 tests).
+
+Full suite: `pytest tests/ -v`
+Expected: green. If any existing `_update_zone_devices` or `ZoneHandler.process_zone_moisture` test starts failing, it likely asserted on the old `"moisture"` key. Update those assertions to expect `"moistureForecast"` on the zone-update side. `ZoneHandler.process_zone_moisture` itself still returns `"moisture"` — don't modify the handler or its direct tests.
+
+**Step 6: Commit**
+
+```bash
+git add "Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py" tests/test_update_zone_devices_integration.py
+git commit -m "feat(netro): resolve zone moisture source in update loop (#54)"
+```
+
+---
+
+## Task 9: Update API_NOTES.md §6
+
+**Files:**
+- Modify: `docs/API_NOTES.md`
+
+**Step 1: Find §6**
+
+Run: `grep -n "^#.*6\|^##.*6\|moisture" docs/API_NOTES.md | head -20`
+
+Locate the section that discusses `/moistures.json` staleness (should mention "12–24 hours" based on the issue text).
+
+**Step 2: Rewrite the section**
+
+Replace the old "can be 12-24 hours old" framing with:
+
+```markdown
+## §6 · `/moistures.json` — predictions, not sensor readings
+
+`/moistures.json` returns Netro's **smart-model daily prediction** for each
+zone, *not* a sampled sensor value. The model assumes full saturation
+immediately after irrigation, then decays based on local weather inputs.
+For a zone with **no** paired Whisperer, this is the best signal
+available. For a zone **with** a paired Whisperer (pairing done in the
+Netro mobile app), Netro's app overlays the Whisperer's reading on the
+zone tile, but **the `/moistures.json` response itself continues to
+return the prediction** — the public API does not expose the app-side
+overlay.
+
+This means the plugin's zone `moisture` state will diverge from a
+paired Whisperer's actual reading whenever the model and reality
+disagree. Observed example: same zone, same moment — `/moistures.json`
+= 89%, paired Whisperer = 24%.
+
+**Plugin behavior:**
+
+- The zone `moistureForecast` state always holds the raw
+  `/moistures.json` value.
+- The zone `moisture` state resolves to: the paired Whisperer's current
+  `soilMoisture` if the pairing is configured on the zone device and
+  the reading is less than 12 hours old, else `moistureForecast`.
+- Pairing is plugin-side (zone ConfigUI → "Paired Whisperer" dropdown),
+  independent of any Netro-side pairing. Both can coexist; they don't
+  interact.
+
+**Open empirical question:** whether `/moistures.json` continues to
+produce sane predictions when a Whisperer is paired on Netro's side but
+has stopped reporting (dead battery, unplugged). The issue-#54
+investigation showed `/moistures.json` returning a saturation-based
+prediction even with a working paired Whisperer, suggesting the
+prediction is independent of Whisperer reporting state. Recommend
+dogfooding with a disconnected Whisperer for a week before relying on
+the fallback in production.
+```
+
+(Adjust heading level to match the surrounding file.)
+
+**Step 3: Commit**
+
+```bash
+git add docs/API_NOTES.md
+git commit -m "docs(netro): clarify /moistures.json is prediction + pairing notes (#54)"
+```
+
+---
+
+## Task 10: Update README
+
+**Files:**
+- Modify: `README.md` (root of repo)
+
+**Step 1: Find the Whisperer section**
+
+Run: `grep -n -i "whisperer" README.md | head -5`
+
+**Step 2: Add a short note**
+
+Under or near the existing Whisperer section, add:
+
+```markdown
+### Pairing a Whisperer to a Zone
+
+Each zone device has a **Paired Whisperer** dropdown in its config UI.
+When paired and the Whisperer has reported within the last 12 hours,
+the zone's `moisture` state mirrors the Whisperer's `soilMoisture`
+reading (the actual measured value). Otherwise the zone falls back to
+Netro's daily forecast.
+
+The `/moistures.json` forecast is always visible separately on the
+`moistureForecast` state — useful for comparing model predictions to
+the sensor's ground truth, and for tuning schedules. See
+[`docs/API_NOTES.md`](docs/API_NOTES.md) §6 for details.
+```
+
+**Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(netro): document Whisperer-zone pairing in README (#54)"
+```
+
+---
+
+## Task 11: Final verification + version bump
+
+**Step 1: Run the full suite one more time**
+
+Run: `pytest tests/ -v --tb=short`
+Expected: all tests pass. Confirm the new tests are all included:
+
+- `tests/test_constants_whisperer.py`
+- `tests/test_reading_age.py`
+- `tests/test_whisperer_pairing_callback.py`
+- `tests/test_zone_moisture_resolution.py`
+- `tests/test_moisture_source_logging.py`
+- `tests/test_update_zone_devices_integration.py`
+
+**Step 2: Run pylint on changed modules**
+
+Run:
+```
+pylint "Netro Sprinklers.indigoPlugin/Contents/Server Plugin/plugin.py" \
+       "Netro Sprinklers.indigoPlugin/Contents/Server Plugin/utils.py" \
+       "Netro Sprinklers.indigoPlugin/Contents/Server Plugin/constants.py"
+```
+Expected: no new issues introduced. (Match the existing baseline score — don't regress.)
+
+**Step 3: Bump `PluginVersion` in Info.plist**
+
+Run: `grep -A1 "PluginVersion" "Netro Sprinklers.indigoPlugin/Contents/Info.plist"` to read current version.
+
+Compute new version: the workspace convention is `YYYY.R.P` where R increments for user-visible features. This change adds new ConfigUI + new state → **minor bump** (R+1, P=0).
+
+Edit `Info.plist` to change the existing `<string>X.Y.Z</string>` immediately after `<key>PluginVersion</key>` to the new value. Verify the file still parses:
+
+Run: `plutil -lint "Netro Sprinklers.indigoPlugin/Contents/Info.plist"`
+Expected: `OK`.
+
+**Step 4: Commit the bump**
+
+```bash
+git add "Netro Sprinklers.indigoPlugin/Contents/Info.plist"
+git commit -m "chore(netro): bump PluginVersion for Whisperer-zone pairing (#54)"
+```
+
+**Step 5: Push the branch**
+
+```bash
+git push -u origin feat/whisperer-zone-pairing
+```
+
+Expected: remote accepts the branch. Do **not** open the PR from this plan — the user will create the PR (per workspace feedback rule: wait for explicit go-ahead before merging or opening PRs is user-driven via the `/ship` or `gh pr create` workflow).
+
+---
+
+## Post-implementation checklist (do NOT run as tasks — user confirms)
+
+- [ ] All 11 tasks complete on `feat/whisperer-zone-pairing`.
+- [ ] `pytest tests/ -v` green.
+- [ ] `pylint` on changed modules: no new issues.
+- [ ] `Info.plist` version bumped (minor: R+1, P=0).
+- [ ] Branch pushed to `origin/feat/whisperer-zone-pairing`.
+- [ ] User opens PR referencing #54; CI (`version-check` + tests) green.
+- [ ] User dogfoods the fallback behavior with a physically disconnected
+      Whisperer for ~1 week before merge (validates the open empirical
+      question from the design doc §"Netro-side pairing").
+
+## Not in scope for this plan
+
+- Bulk-pairing action or UI.
+- Auto-pairing heuristic.
+- Changes to Netro `set_moisture` action, `ZoneHandler.process_zone_moisture`
+  internals, or Whisperer update loop.
+- Integration tests against the live Netro API (local testing documented
+  separately in `docs/LOCAL_TESTING.md`).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,11 +193,15 @@ def sample_v2_schedules():
 
 
 class _IndigoPluginBaseStub:
-    """Stand-in for indigo.PluginBase used at Plugin class definition time.
+    """Stand-in for ``indigo.PluginBase`` used at Plugin class definition time.
 
-    Real Indigo's PluginBase performs server-bound initialisation the tests
-    don't need; subclassing this empty stub lets `class Plugin(indigo.PluginBase):`
-    succeed under MagicMock-based test doubles.
+    Real Indigo's ``PluginBase`` performs server-bound initialisation the
+    tests don't need; subclassing this empty stub lets
+    ``class Plugin(indigo.PluginBase):`` import-succeed under
+    MagicMock-based test doubles. The class is deliberately method-less —
+    any base-class behaviour exercised by tests (e.g. ``self.logger``) is
+    supplied per-test, not by this stub. See also ``mock_indigo_base``
+    which installs this into ``sys.modules['indigo']``.
     """
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ mechanism.
 """
 import sys
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 import pytest
 
 # Add Server Plugin directory to path for imports
@@ -190,6 +190,30 @@ def sample_v2_schedules():
             "token_reset": "2026-04-08T00:00:00"
         }
     }
+
+
+class _IndigoPluginBaseStub:
+    """Stand-in for indigo.PluginBase used at Plugin class definition time.
+
+    Real Indigo's PluginBase performs server-bound initialisation the tests
+    don't need; subclassing this empty stub lets `class Plugin(indigo.PluginBase):`
+    succeed under MagicMock-based test doubles.
+    """
+
+
+@pytest.fixture
+def mock_indigo_base(monkeypatch):
+    """Install a minimal indigo module into sys.modules.
+
+    Tests that need `indigo.devices[id]` lookups can extend the returned
+    MagicMock with their own `_devices_by_id` dict and side_effect.
+    """
+    indigo = MagicMock()
+    indigo.PluginBase = _IndigoPluginBaseStub
+    indigo.Dict = dict
+    monkeypatch.setitem(sys.modules, "indigo", indigo)
+    monkeypatch.delitem(sys.modules, "plugin", raising=False)
+    return indigo
 
 
 @pytest.fixture

--- a/tests/test_constants_whisperer.py
+++ b/tests/test_constants_whisperer.py
@@ -1,0 +1,14 @@
+"""Tests for Whisperer-specific constants."""
+import constants
+
+
+def test_whisperer_staleness_hours_defined():
+    """WHISPERER_STALENESS_HOURS should be defined as a positive integer."""
+    assert hasattr(constants, "WHISPERER_STALENESS_HOURS")
+    assert isinstance(constants.WHISPERER_STALENESS_HOURS, int)
+    assert constants.WHISPERER_STALENESS_HOURS > 0
+
+
+def test_whisperer_staleness_hours_value():
+    """WHISPERER_STALENESS_HOURS should be 12 hours (2-12 missed readings at 1-6h cadence)."""
+    assert constants.WHISPERER_STALENESS_HOURS == 12

--- a/tests/test_moisture_source_logging.py
+++ b/tests/test_moisture_source_logging.py
@@ -111,3 +111,20 @@ def test_repeated_warning_suppressed(plugin_instance):
     plugin_instance._log_moisture_source_transition(zone, "forecast-stale")
     plugin_instance._log_moisture_source_transition(zone, "forecast-stale")
     assert plugin_instance.logger.warning.call_count == 1
+
+
+def test_replace_props_failure_logs_warning_not_raises(plugin_instance):
+    """If replacePluginPropsOnServer raises, logger.warning is called and no exception escapes."""
+    zone = _zone(last_source="whisperer")
+
+    def _failing_replace(new_props):
+        raise RuntimeError("IOM hiccup")
+
+    zone.replacePluginPropsOnServer = _failing_replace
+    # Should not raise.
+    plugin_instance._log_moisture_source_transition(zone, "forecast-stale")
+    # The stale transition warning AND the persistence-failure warning should both have fired.
+    assert plugin_instance.logger.warning.call_count >= 1
+    # Verify at least one warning mentions persistence failure.
+    messages = [call.args[0] for call in plugin_instance.logger.warning.call_args_list]
+    assert any("could not persist moisture source" in m for m in messages)

--- a/tests/test_moisture_source_logging.py
+++ b/tests/test_moisture_source_logging.py
@@ -1,27 +1,12 @@
 """Tests for Plugin._log_moisture_source_transition."""
-import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 
-class _PluginBase:
-    """Stand-in for indigo.PluginBase."""
-
-
 @pytest.fixture
-def mock_indigo(monkeypatch):
-    indigo = MagicMock()
-    indigo.PluginBase = _PluginBase
-    indigo.Dict = dict
-    monkeypatch.setitem(sys.modules, "indigo", indigo)
-    monkeypatch.delitem(sys.modules, "plugin", raising=False)
-    return indigo
-
-
-@pytest.fixture
-def plugin_instance(mock_indigo):
+def plugin_instance(mock_indigo_base):
     from plugin import Plugin  # noqa: WPS433
     plugin = Plugin.__new__(Plugin)
     plugin.logger = MagicMock()
@@ -56,6 +41,17 @@ def test_no_log_when_source_unchanged(plugin_instance):
     plugin_instance.logger.info.assert_not_called()
     # pluginProps still reflect the (unchanged) value.
     assert zone.pluginProps.get("lastMoistureSource") == "whisperer"
+    # Repeated calls with same source must not hit replacePluginPropsOnServer.
+    assert zone._replaced == []
+
+
+def test_no_log_when_cold_start_whisperer(plugin_instance):
+    """Paired zone, first poll with no prior lastMoistureSource → silent."""
+    zone = _zone(last_source=None)
+    plugin_instance._log_moisture_source_transition(zone, "whisperer")
+    plugin_instance.logger.warning.assert_not_called()
+    plugin_instance.logger.info.assert_not_called()
+    assert zone.pluginProps["lastMoistureSource"] == "whisperer"
 
 
 def test_log_info_on_forecast_to_whisperer(plugin_instance):

--- a/tests/test_moisture_source_logging.py
+++ b/tests/test_moisture_source_logging.py
@@ -131,6 +131,14 @@ def test_log_warning_on_unparseable_time(plugin_instance):
     assert "unparseable" in plugin_instance.logger.warning.call_args[0][0].lower()
 
 
+def test_log_warning_on_invalid_reading(plugin_instance):
+    """Paired, but soilMoisture is non-numeric → distinct warning from missing-reading."""
+    zone = _zone(last_source="whisperer")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-invalid-reading")
+    plugin_instance.logger.warning.assert_called_once()
+    assert "non-numeric soil value" in plugin_instance.logger.warning.call_args[0][0].lower()
+
+
 def test_replace_props_failure_logs_warning_not_raises(plugin_instance):
     """If replacePluginPropsOnServer raises, logger.warning is called and no exception escapes."""
     zone = _zone(last_source="whisperer")

--- a/tests/test_moisture_source_logging.py
+++ b/tests/test_moisture_source_logging.py
@@ -13,6 +13,9 @@ def plugin_instance(mock_indigo_base):
     return plugin
 
 
+_NEXT_ZONE_ID = [9000]
+
+
 def _zone(last_source=None, name="Test Zone"):
     """A fake zone with a mutable pluginProps dict and a replacePluginPropsOnServer stub."""
     props = {}
@@ -26,7 +29,10 @@ def _zone(last_source=None, name="Test Zone"):
         props.clear()
         props.update(new_props)
 
+    # Each fake zone gets a unique id so the in-memory transition cache can key on it.
+    _NEXT_ZONE_ID[0] += 1
     return SimpleNamespace(
+        id=_NEXT_ZONE_ID[0],
         name=name,
         pluginProps=props,
         replacePluginPropsOnServer=_replace,
@@ -140,3 +146,29 @@ def test_replace_props_failure_logs_warning_not_raises(plugin_instance):
     # Verify at least one warning mentions persistence failure.
     messages = [call.args[0] for call in plugin_instance.logger.warning.call_args_list]
     assert any("could not persist moisture source" in m for m in messages)
+
+
+def test_repeated_transition_with_persist_failure_logs_once(plugin_instance):
+    """When replacePluginPropsOnServer keeps failing, the transition log fires only once.
+
+    Pre-fix: every poll re-logged the same transition because pluginProps never updated.
+    Post-fix: in-memory cache prevents the spam while IOM is broken.
+    """
+    zone = _zone(last_source="whisperer")
+    # Give the zone an id so the in-memory cache can key on it.
+    zone.id = 1234
+    zone.replacePluginPropsOnServer = lambda new_props: (_ for _ in ()).throw(RuntimeError("IOM"))
+
+    # First call: transition logs the stale warning + the persist-failure warning.
+    plugin_instance._log_moisture_source_transition(zone, "forecast-stale")
+
+    # Second and third calls with the SAME source must not re-log the transition.
+    plugin_instance._log_moisture_source_transition(zone, "forecast-stale")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-stale")
+
+    # Persistence still fails on every call, but the *transition* warning fires only once.
+    transition_msgs = [
+        c.args[0] for c in plugin_instance.logger.warning.call_args_list
+        if "stale" in c.args[0].lower() and "Netro forecast" in c.args[0]
+    ]
+    assert len(transition_msgs) == 1, transition_msgs

--- a/tests/test_moisture_source_logging.py
+++ b/tests/test_moisture_source_logging.py
@@ -113,6 +113,22 @@ def test_repeated_warning_suppressed(plugin_instance):
     assert plugin_instance.logger.warning.call_count == 1
 
 
+def test_log_warning_on_missing_reading(plugin_instance):
+    """Paired, but Whisperer has no reading yet (readingID==0) → warning."""
+    zone = _zone(last_source="whisperer")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-missing-reading")
+    plugin_instance.logger.warning.assert_called_once()
+    assert "no reading yet" in plugin_instance.logger.warning.call_args[0][0].lower()
+
+
+def test_log_warning_on_unparseable_time(plugin_instance):
+    """Paired, but readingTime can't be parsed → warning."""
+    zone = _zone(last_source="whisperer")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-unparseable-time")
+    plugin_instance.logger.warning.assert_called_once()
+    assert "unparseable" in plugin_instance.logger.warning.call_args[0][0].lower()
+
+
 def test_replace_props_failure_logs_warning_not_raises(plugin_instance):
     """If replacePluginPropsOnServer raises, logger.warning is called and no exception escapes."""
     zone = _zone(last_source="whisperer")

--- a/tests/test_moisture_source_logging.py
+++ b/tests/test_moisture_source_logging.py
@@ -37,6 +37,9 @@ def _zone(last_source=None, name="Test Zone"):
 
     def _replace(new_props):
         replaced.append(dict(new_props))
+        # Simulate Indigo's real behavior: pluginProps reflects the server write.
+        props.clear()
+        props.update(new_props)
 
     return SimpleNamespace(
         name=name,

--- a/tests/test_moisture_source_logging.py
+++ b/tests/test_moisture_source_logging.py
@@ -1,0 +1,110 @@
+"""Tests for Plugin._log_moisture_source_transition."""
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _PluginBase:
+    """Stand-in for indigo.PluginBase."""
+
+
+@pytest.fixture
+def mock_indigo(monkeypatch):
+    indigo = MagicMock()
+    indigo.PluginBase = _PluginBase
+    indigo.Dict = dict
+    monkeypatch.setitem(sys.modules, "indigo", indigo)
+    monkeypatch.delitem(sys.modules, "plugin", raising=False)
+    return indigo
+
+
+@pytest.fixture
+def plugin_instance(mock_indigo):
+    from plugin import Plugin  # noqa: WPS433
+    plugin = Plugin.__new__(Plugin)
+    plugin.logger = MagicMock()
+    return plugin
+
+
+def _zone(last_source=None, name="Test Zone"):
+    """A fake zone with a mutable pluginProps dict and a replacePluginPropsOnServer stub."""
+    props = {}
+    if last_source is not None:
+        props["lastMoistureSource"] = last_source
+    replaced = []
+
+    def _replace(new_props):
+        replaced.append(dict(new_props))
+
+    return SimpleNamespace(
+        name=name,
+        pluginProps=props,
+        replacePluginPropsOnServer=_replace,
+        _replaced=replaced,
+    )
+
+
+def test_no_log_when_source_unchanged(plugin_instance):
+    zone = _zone(last_source="whisperer")
+    plugin_instance._log_moisture_source_transition(zone, "whisperer")
+    plugin_instance.logger.warning.assert_not_called()
+    plugin_instance.logger.info.assert_not_called()
+    # pluginProps still reflect the (unchanged) value.
+    assert zone.pluginProps.get("lastMoistureSource") == "whisperer"
+
+
+def test_log_info_on_forecast_to_whisperer(plugin_instance):
+    zone = _zone(last_source="forecast")
+    plugin_instance._log_moisture_source_transition(zone, "whisperer")
+    plugin_instance.logger.info.assert_called_once()
+    assert "Whisperer reading" in plugin_instance.logger.info.call_args[0][0]
+    assert zone.pluginProps["lastMoistureSource"] == "whisperer"
+
+
+def test_log_warning_on_whisperer_to_stale(plugin_instance):
+    zone = _zone(last_source="whisperer")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-stale")
+    plugin_instance.logger.warning.assert_called_once()
+    msg = plugin_instance.logger.warning.call_args[0][0]
+    assert "stale" in msg.lower()
+    assert "forecast" in msg.lower()
+
+
+def test_log_info_on_stale_to_whisperer(plugin_instance):
+    zone = _zone(last_source="forecast-stale")
+    plugin_instance._log_moisture_source_transition(zone, "whisperer")
+    plugin_instance.logger.info.assert_called_once()
+    assert "recovered" in plugin_instance.logger.info.call_args[0][0].lower()
+
+
+def test_log_warning_on_missing_device(plugin_instance):
+    zone = _zone(last_source="whisperer")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-missing-device")
+    plugin_instance.logger.warning.assert_called_once()
+    assert "no longer" in plugin_instance.logger.warning.call_args[0][0].lower()
+
+
+def test_log_warning_on_disabled_device(plugin_instance):
+    zone = _zone(last_source="whisperer")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-disabled-device")
+    plugin_instance.logger.warning.assert_called_once()
+    assert "disabled" in plugin_instance.logger.warning.call_args[0][0].lower()
+
+
+def test_no_log_when_cold_start_forecast(plugin_instance):
+    """Fresh install, first-ever poll on an unpaired zone → silent (no transition)."""
+    zone = _zone(last_source=None)
+    plugin_instance._log_moisture_source_transition(zone, "forecast")
+    plugin_instance.logger.warning.assert_not_called()
+    plugin_instance.logger.info.assert_not_called()
+    assert zone.pluginProps["lastMoistureSource"] == "forecast"
+
+
+def test_repeated_warning_suppressed(plugin_instance):
+    """Same stale source across two polls logs only once."""
+    zone = _zone(last_source="whisperer")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-stale")
+    plugin_instance._log_moisture_source_transition(zone, "forecast-stale")
+    assert plugin_instance.logger.warning.call_count == 1

--- a/tests/test_reading_age.py
+++ b/tests/test_reading_age.py
@@ -74,3 +74,15 @@ class TestParseReadingAgeHours:
         with patch("utils._now_utc", return_value=fixed_now):
             age = utils.parse_reading_age_hours(future)
         assert age == 0.0
+
+    def test_bool_input_returns_none(self):
+        """Booleans (subclass of int) must NOT be treated as epoch millis."""
+        assert utils.parse_reading_age_hours(True) is None
+        assert utils.parse_reading_age_hours(False) is None
+
+    def test_iso_with_triple_z_suffix_rejected(self):
+        """Malformed ISO with multiple 'Z's is not silently stripped to valid."""
+        # Only a single trailing 'Z' is accepted; "...ZZZ" is malformed input
+        # and should return None rather than silently parsing as if it were "...Z".
+        result = utils.parse_reading_age_hours("2026-04-23T10:00:00ZZZ")
+        assert result is None

--- a/tests/test_reading_age.py
+++ b/tests/test_reading_age.py
@@ -1,0 +1,76 @@
+"""Tests for parse_reading_age_hours utility."""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+import utils
+
+
+class TestParseReadingAgeHours:
+    """Test utils.parse_reading_age_hours across supported input formats."""
+
+    @pytest.fixture
+    def fixed_now(self):
+        """Anchor "now" to a known UTC datetime for deterministic age math."""
+        return datetime(2026, 4, 23, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_v2_iso_string_fresh(self, fixed_now):
+        """ISO-8601 string 3h old → ~3.0 hours."""
+        three_hours_ago = (fixed_now - timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%S")
+        with patch("utils._now_utc", return_value=fixed_now):
+            age = utils.parse_reading_age_hours(three_hours_ago)
+        assert age is not None
+        assert 2.9 <= age <= 3.1
+
+    def test_v2_iso_string_with_timezone(self, fixed_now):
+        """ISO-8601 string with Z suffix should be treated as UTC."""
+        three_hours_ago = (fixed_now - timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with patch("utils._now_utc", return_value=fixed_now):
+            age = utils.parse_reading_age_hours(three_hours_ago)
+        assert age is not None
+        assert 2.9 <= age <= 3.1
+
+    def test_v1_epoch_millis_fresh(self, fixed_now):
+        """V1 epoch millis 3h old → ~3.0 hours."""
+        epoch_ms = int((fixed_now - timedelta(hours=3)).timestamp() * 1000)
+        with patch("utils._now_utc", return_value=fixed_now):
+            age = utils.parse_reading_age_hours(epoch_ms)
+        assert age is not None
+        assert 2.9 <= age <= 3.1
+
+    def test_v1_epoch_millis_as_string(self, fixed_now):
+        """Epoch millis passed as a string should still parse."""
+        epoch_ms_str = str(int((fixed_now - timedelta(hours=3)).timestamp() * 1000))
+        with patch("utils._now_utc", return_value=fixed_now):
+            age = utils.parse_reading_age_hours(epoch_ms_str)
+        assert age is not None
+        assert 2.9 <= age <= 3.1
+
+    def test_stale_reading(self, fixed_now):
+        """24h-old reading → 24.0 hours (above threshold)."""
+        one_day_ago = (fixed_now - timedelta(hours=24)).strftime("%Y-%m-%dT%H:%M:%S")
+        with patch("utils._now_utc", return_value=fixed_now):
+            age = utils.parse_reading_age_hours(one_day_ago)
+        assert age is not None
+        assert 23.9 <= age <= 24.1
+
+    def test_unparseable_string_returns_none(self):
+        """Garbage input returns None, does not raise."""
+        assert utils.parse_reading_age_hours("not-a-timestamp") is None
+        assert utils.parse_reading_age_hours("unknown") is None
+
+    def test_empty_string_returns_none(self):
+        """Empty string returns None."""
+        assert utils.parse_reading_age_hours("") is None
+
+    def test_none_input_returns_none(self):
+        """None input returns None."""
+        assert utils.parse_reading_age_hours(None) is None
+
+    def test_negative_age_clamped_to_zero(self, fixed_now):
+        """Future timestamp (clock skew) returns 0.0, never negative."""
+        future = (fixed_now + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
+        with patch("utils._now_utc", return_value=fixed_now):
+            age = utils.parse_reading_age_hours(future)
+        assert age == 0.0

--- a/tests/test_update_zone_devices_integration.py
+++ b/tests/test_update_zone_devices_integration.py
@@ -1,0 +1,209 @@
+"""Integration tests for Plugin._update_zone_devices moisture resolution.
+
+These tests verify the call-site rewiring:
+  - moistureForecast gets the /moistures.json value.
+  - moisture gets the resolved value (Whisperer if fresh + paired, else forecast).
+  - Source transitions are logged.
+"""
+import sys
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+FROZEN_NOW = datetime(2026, 4, 23, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class _PluginBase:
+    pass
+
+
+@pytest.fixture
+def mock_indigo(monkeypatch):
+    indigo = MagicMock()
+    indigo.PluginBase = _PluginBase
+    indigo.Dict = dict
+    indigo._devices_by_id = {}
+
+    def _getitem(dev_id):
+        if dev_id not in indigo._devices_by_id:
+            raise KeyError(dev_id)
+        return indigo._devices_by_id[dev_id]
+
+    indigo.devices.__getitem__.side_effect = _getitem
+    monkeypatch.setitem(sys.modules, "indigo", indigo)
+    monkeypatch.delitem(sys.modules, "plugin", raising=False)
+    return indigo
+
+
+@pytest.fixture
+def plugin_instance(mock_indigo):
+    from plugin import Plugin  # noqa: WPS433
+    plugin = Plugin.__new__(Plugin)
+    plugin.logger = MagicMock()
+    from device_handlers import ZoneHandler
+    plugin.zone_handler = ZoneHandler(logger=MagicMock())
+    return plugin
+
+
+def _zone_dev(zone_num=1, linked_id="", name="Front Lawn"):
+    """Build a zone device double that captures state + prop writes.
+
+    The zone must look enabled in the extracted-zone-states so the moisture
+    block runs; that requires ``zones`` in ``device_data`` to mark the zone
+    as enabled, not the device itself. ``enabled`` here controls the Indigo
+    device-enabled flag, not the zone's ``enabled`` state.
+    """
+    replaced_states = []
+    replaced_props = []
+
+    def _update_states(states):
+        replaced_states.extend(states)
+
+    def _replace_props(props):
+        replaced_props.append(dict(props))
+
+    dev = SimpleNamespace(
+        id=1000 + zone_num,
+        name=name,
+        pluginProps={
+            "zoneNumber": str(zone_num),
+            "linkedWhispererDeviceId": linked_id,
+        },
+        enabled=True,
+        states={},
+        deviceTypeId="zone",
+        updateStatesOnServer=_update_states,
+        replacePluginPropsOnServer=_replace_props,
+        setErrorStateOnServer=lambda *a, **kw: None,
+        updateStateImageOnServer=lambda *a, **kw: None,
+        _replaced_states=replaced_states,
+        _replaced_props=replaced_props,
+    )
+    return dev
+
+
+def _whisperer(soil=24, hours_old=2):
+    return SimpleNamespace(
+        enabled=True,
+        states={
+            "soilMoisture": soil,
+            "readingTime": (FROZEN_NOW - timedelta(hours=hours_old)).strftime(
+                "%Y-%m-%dT%H:%M:%S"
+            ),
+        },
+    )
+
+
+def _moistures_response(zone_num, forecast_val):
+    return {
+        "status": "OK",
+        "data": {
+            "moistures": [
+                {
+                    "id": 1,
+                    "zone": zone_num,
+                    "date": "2026-04-23",
+                    "moisture": forecast_val,
+                },
+            ],
+        },
+    }
+
+
+def _device_data(zone_num=1):
+    """Return a minimal device_data with a single enabled zone.
+
+    ``_update_zone_devices`` pulls ``zones`` out of ``device_data`` and
+    passes them to ``ZoneHandler.extract_zone_states`` which uses the
+    ``enabled`` flag on the matching zone to decide whether to run the
+    moisture block.
+    """
+    return {
+        "zones": [
+            {"ith": zone_num, "name": f"Zone {zone_num}", "enabled": True,
+             "smart": "SMART"},
+        ],
+    }
+
+
+def test_paired_fresh_writes_sensor_to_moisture_and_forecast_to_moistureForecast(
+    plugin_instance, mock_indigo
+):
+    zone = _zone_dev(zone_num=1, linked_id="999")
+    mock_indigo._devices_by_id[999] = _whisperer(soil=24, hours_old=2)
+    plugin_instance._get_zone_devices = lambda parent_id: {1: zone}
+    parent = SimpleNamespace(id=42, name="Sprite")
+
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        plugin_instance._update_zone_devices(
+            parent,
+            _device_data(1),
+            schedule_response=None,
+            moisture_response=_moistures_response(1, forecast_val=89),
+            api_version="1",
+        )
+
+    keys = {s["key"]: s["value"] for s in zone._replaced_states}
+    assert keys["moisture"] == 24
+    assert keys["moistureForecast"] == 89
+
+
+def test_unpaired_zone_mirrors_forecast_to_both(plugin_instance, mock_indigo):
+    zone = _zone_dev(zone_num=1, linked_id="")
+    plugin_instance._get_zone_devices = lambda parent_id: {1: zone}
+    parent = SimpleNamespace(id=42, name="Sprite")
+
+    plugin_instance._update_zone_devices(
+        parent,
+        _device_data(1),
+        schedule_response=None,
+        moisture_response=_moistures_response(1, forecast_val=55),
+        api_version="1",
+    )
+
+    keys = {s["key"]: s["value"] for s in zone._replaced_states}
+    assert keys["moisture"] == 55
+    assert keys["moistureForecast"] == 55
+
+
+def test_missing_moisture_response_skips_both_writes(plugin_instance, mock_indigo):
+    zone = _zone_dev(zone_num=1, linked_id="")
+    plugin_instance._get_zone_devices = lambda parent_id: {1: zone}
+    parent = SimpleNamespace(id=42, name="Sprite")
+
+    plugin_instance._update_zone_devices(
+        parent,
+        _device_data(1),
+        schedule_response=None,
+        moisture_response=None,
+        api_version="1",
+    )
+
+    keys = {s["key"]: s.get("value") for s in zone._replaced_states}
+    # When paired=no and forecast missing, we skip writing moisture.
+    assert "moisture" not in keys
+    assert "moistureForecast" not in keys
+
+
+def test_missing_forecast_but_paired_fresh_writes_sensor(plugin_instance, mock_indigo):
+    zone = _zone_dev(zone_num=1, linked_id="999")
+    mock_indigo._devices_by_id[999] = _whisperer(soil=24, hours_old=2)
+    plugin_instance._get_zone_devices = lambda parent_id: {1: zone}
+    parent = SimpleNamespace(id=42, name="Sprite")
+
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        plugin_instance._update_zone_devices(
+            parent,
+            _device_data(1),
+            schedule_response=None,
+            moisture_response=None,
+            api_version="1",
+        )
+
+    keys = {s["key"]: s["value"] for s in zone._replaced_states}
+    assert keys["moisture"] == 24
+    # No moistureForecast write when moisture_response is None.
+    assert "moistureForecast" not in keys

--- a/tests/test_update_zone_devices_integration.py
+++ b/tests/test_update_zone_devices_integration.py
@@ -89,7 +89,7 @@ def _zone_dev(zone_num=1, linked_id="", name="Front Lawn"):
     return dev
 
 
-def _whisperer(soil=24, hours_old=2):
+def _whisperer(soil=24, hours_old=2, reading_id=1001):
     return SimpleNamespace(
         enabled=True,
         states={
@@ -97,6 +97,7 @@ def _whisperer(soil=24, hours_old=2):
             "readingTime": (FROZEN_NOW - timedelta(hours=hours_old)).strftime(
                 "%Y-%m-%dT%H:%M:%S"
             ),
+            "readingID": reading_id,
         },
     )
 

--- a/tests/test_update_zone_devices_integration.py
+++ b/tests/test_update_zone_devices_integration.py
@@ -207,3 +207,24 @@ def test_missing_forecast_but_paired_fresh_writes_sensor(plugin_instance, mock_i
     assert keys["moisture"] == 24
     # No moistureForecast write when moisture_response is None.
     assert "moistureForecast" not in keys
+
+
+def test_paired_stale_falls_back_to_forecast(plugin_instance, mock_indigo):
+    """End-to-end: paired Whisperer with stale reading → moisture shows forecast."""
+    zone = _zone_dev(zone_num=1, linked_id="999")
+    mock_indigo._devices_by_id[999] = _whisperer(soil=24, hours_old=20)
+    plugin_instance._get_zone_devices = lambda parent_id: {1: zone}
+    parent = SimpleNamespace(id=42, name="Sprite")
+
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        plugin_instance._update_zone_devices(
+            parent, _device_data(),
+            schedule_response=None,
+            moisture_response=_moistures_response(1, forecast_val=89),
+            api_version="1",
+        )
+
+    keys = {s["key"]: s["value"] for s in zone._replaced_states}
+    # Stale Whisperer → fall back to forecast for both states.
+    assert keys["moisture"] == 89
+    assert keys["moistureForecast"] == 89

--- a/tests/test_update_zone_devices_integration.py
+++ b/tests/test_update_zone_devices_integration.py
@@ -58,20 +58,24 @@ def _zone_dev(zone_num=1, linked_id="", name="Front Lawn"):
     """
     replaced_states = []
     replaced_props = []
+    props = {
+        "zoneNumber": str(zone_num),
+        "linkedWhispererDeviceId": linked_id,
+    }
 
     def _update_states(states):
         replaced_states.extend(states)
 
-    def _replace_props(props):
-        replaced_props.append(dict(props))
+    def _replace_props(new_props):
+        replaced_props.append(dict(new_props))
+        # Simulate Indigo's real behavior: pluginProps reflects the server write.
+        props.clear()
+        props.update(new_props)
 
     dev = SimpleNamespace(
         id=1000 + zone_num,
         name=name,
-        pluginProps={
-            "zoneNumber": str(zone_num),
-            "linkedWhispererDeviceId": linked_id,
-        },
+        pluginProps=props,
         enabled=True,
         states={},
         deviceTypeId="zone",

--- a/tests/test_update_zone_devices_integration.py
+++ b/tests/test_update_zone_devices_integration.py
@@ -266,3 +266,31 @@ def test_paired_stale_falls_back_to_forecast(plugin_instance, mock_indigo):
     # Stale Whisperer → fall back to forecast for both states.
     assert keys["moisture"] == 89
     assert keys["moistureForecast"] == 89
+
+
+def test_resolver_exception_falls_back_to_forecast(plugin_instance, mock_indigo, monkeypatch):
+    """If _resolve_zone_moisture raises, the zone falls back to forecast and other states still write."""
+    zone = _zone_dev(zone_num=1, linked_id="999")
+    plugin_instance._get_zone_devices = lambda pid: {1: zone}
+    parent = SimpleNamespace(id=42, name="Sprite")
+
+    def _bad_resolver(*args, **kwargs):
+        raise AttributeError("simulated IOM corruption")
+
+    monkeypatch.setattr(plugin_instance, "_resolve_zone_moisture", _bad_resolver)
+
+    plugin_instance._update_zone_devices(
+        parent, _device_data(),
+        schedule_response=None,
+        moisture_response=_moistures_response(1, forecast_val=55),
+        api_version="1",
+    )
+
+    keys = {s["key"]: s["value"] for s in zone._replaced_states}
+    # Forecast still wrote (the resolver failed AFTER moistureForecast was added):
+    assert keys.get("moistureForecast") == 55
+    # Moisture wrote with forecast fallback (resolver returned (forecast_val, "forecast")):
+    assert keys.get("moisture") == 55
+    # Warning was emitted with the right context:
+    msgs = [c.args[0] for c in plugin_instance.logger.warning.call_args_list]
+    assert any("could not resolve moisture source" in m for m in msgs)

--- a/tests/test_update_zone_devices_integration.py
+++ b/tests/test_update_zone_devices_integration.py
@@ -225,6 +225,10 @@ def test_source_transition_logged_during_update(plugin_instance, mock_indigo):
     assert plugin_instance.logger.warning.call_count >= 1
     # The transition should have been recorded.
     assert zone.pluginProps.get("lastMoistureSource") == "forecast-stale"
+    # Pin the user-facing wording so a refactor of the warning message would fail loudly.
+    warn_msgs = [c.args[0] for c in plugin_instance.logger.warning.call_args_list]
+    assert any("stale" in m.lower() for m in warn_msgs), warn_msgs
+    assert any("Netro forecast" in m for m in warn_msgs), warn_msgs
 
 
 def test_empty_moistures_response_skips_forecast_write(plugin_instance, mock_indigo):
@@ -266,6 +270,30 @@ def test_paired_stale_falls_back_to_forecast(plugin_instance, mock_indigo):
     # Stale Whisperer → fall back to forecast for both states.
     assert keys["moisture"] == 89
     assert keys["moistureForecast"] == 89
+
+
+def test_malformed_moisture_response_swallows_and_continues(plugin_instance, mock_indigo):
+    """A malformed moisture_response triggers the inner except; other state writes survive."""
+    zone = _zone_dev(zone_num=1, linked_id="")
+    plugin_instance._get_zone_devices = lambda pid: {1: zone}
+    parent = SimpleNamespace(id=42, name="Sprite")
+
+    # data.moistures wrong shape → handler can return [] cleanly OR (worst case)
+    # caller's loop hits AttributeError on entry.get(). Either way the inner
+    # except in _update_zone_devices must catch it.
+    bogus = {"status": "OK", "data": {"moistures": "not-a-list"}}
+
+    plugin_instance._update_zone_devices(
+        parent, _device_data(),
+        schedule_response=None,
+        moisture_response=bogus,
+        api_version="1",
+    )
+
+    # Test reaches this line means no exception escaped to the outer per-zone try/except.
+    keys = {s["key"] for s in zone._replaced_states}
+    # moistureForecast not written (bogus moistures path):
+    assert "moistureForecast" not in keys
 
 
 def test_resolver_exception_falls_back_to_forecast(plugin_instance, mock_indigo, monkeypatch):

--- a/tests/test_update_zone_devices_integration.py
+++ b/tests/test_update_zone_devices_integration.py
@@ -5,7 +5,6 @@ These tests verify the call-site rewiring:
   - moisture gets the resolved value (Whisperer if fresh + paired, else forecast).
   - Source transitions are logged.
 """
-import sys
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -16,15 +15,10 @@ import pytest
 FROZEN_NOW = datetime(2026, 4, 23, 12, 0, 0, tzinfo=timezone.utc)
 
 
-class _PluginBase:
-    pass
-
-
 @pytest.fixture
-def mock_indigo(monkeypatch):
-    indigo = MagicMock()
-    indigo.PluginBase = _PluginBase
-    indigo.Dict = dict
+def mock_indigo(mock_indigo_base):
+    """Extend the shared mock_indigo_base with a `_devices_by_id` lookup."""
+    indigo = mock_indigo_base
     indigo._devices_by_id = {}
 
     def _getitem(dev_id):
@@ -33,8 +27,6 @@ def mock_indigo(monkeypatch):
         return indigo._devices_by_id[dev_id]
 
     indigo.devices.__getitem__.side_effect = _getitem
-    monkeypatch.setitem(sys.modules, "indigo", indigo)
-    monkeypatch.delitem(sys.modules, "plugin", raising=False)
     return indigo
 
 
@@ -212,6 +204,47 @@ def test_missing_forecast_but_paired_fresh_writes_sensor(plugin_instance, mock_i
     assert keys["moisture"] == 24
     # No moistureForecast write when moisture_response is None.
     assert "moistureForecast" not in keys
+
+
+def test_source_transition_logged_during_update(plugin_instance, mock_indigo):
+    """Verify _update_zone_devices actually wires up the transition logger."""
+    zone = _zone_dev(zone_num=1, linked_id="999")
+    zone.pluginProps["lastMoistureSource"] = "whisperer"  # prior state
+    mock_indigo._devices_by_id[999] = _whisperer(soil=24, hours_old=20)  # now stale
+    plugin_instance._get_zone_devices = lambda parent_id: {1: zone}
+    parent = SimpleNamespace(id=42, name="Sprite")
+
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        plugin_instance._update_zone_devices(
+            parent, _device_data(),
+            schedule_response=None,
+            moisture_response=_moistures_response(1, forecast_val=89),
+            api_version="1",
+        )
+
+    assert plugin_instance.logger.warning.call_count >= 1
+    # The transition should have been recorded.
+    assert zone.pluginProps.get("lastMoistureSource") == "forecast-stale"
+
+
+def test_empty_moistures_response_skips_forecast_write(plugin_instance, mock_indigo):
+    """Empty data.moistures → moistureForecast not written (no fake 0%)."""
+    zone = _zone_dev(zone_num=1, linked_id="")
+    plugin_instance._get_zone_devices = lambda parent_id: {1: zone}
+    parent = SimpleNamespace(id=42, name="Sprite")
+
+    empty_response = {"status": "OK", "data": {"moistures": []}}
+
+    plugin_instance._update_zone_devices(
+        parent, _device_data(),
+        schedule_response=None,
+        moisture_response=empty_response,
+        api_version="1",
+    )
+
+    keys = {s["key"]: s.get("value") for s in zone._replaced_states}
+    assert "moistureForecast" not in keys
+    assert "moisture" not in keys
 
 
 def test_paired_stale_falls_back_to_forecast(plugin_instance, mock_indigo):

--- a/tests/test_whisperer_pairing_callback.py
+++ b/tests/test_whisperer_pairing_callback.py
@@ -1,0 +1,75 @@
+"""Tests for Plugin.getWhispererDevices ConfigUI callback."""
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_indigo(monkeypatch):
+    """Install a minimal `indigo` module into sys.modules for plugin import.
+
+    `PluginBase` must be a real class so `class Plugin(indigo.PluginBase):`
+    at import time produces a real class — not a MagicMock attribute.
+    """
+    indigo = MagicMock()
+
+    class _PluginBase:
+        pass
+
+    indigo.PluginBase = _PluginBase
+    indigo.Dict = dict
+    indigo.devices.iter = MagicMock(return_value=iter([]))
+    monkeypatch.setitem(sys.modules, "indigo", indigo)
+    # Force a fresh import of `plugin` so the Plugin class is rebuilt against
+    # this fixture's mock (previous tests may have cached a stale module).
+    monkeypatch.delitem(sys.modules, "plugin", raising=False)
+    return indigo
+
+
+def _fake_device(dev_id, name, type_id="Whisperer"):
+    return SimpleNamespace(id=dev_id, name=name, deviceTypeId=type_id)
+
+
+def test_returns_unpaired_sentinel_when_no_whisperers(mock_indigo):
+    """With zero Whisperers installed, returns only the unpaired option."""
+    mock_indigo.devices.iter.return_value = iter([])
+    # Import after mock is installed.
+    from plugin import Plugin  # noqa: WPS433
+    plugin = Plugin.__new__(Plugin)  # skip __init__
+    result = plugin.getWhispererDevices()
+    assert result[0] == ("", "(Unpaired — use Netro forecast)")
+    assert len(result) == 1
+
+
+def test_returns_whisperers_sorted_by_name(mock_indigo):
+    """Whisperers are appended, sorted case-insensitively by name."""
+    devs = [
+        _fake_device(101, "Zebra"),
+        _fake_device(102, "apple"),
+        _fake_device(103, "Mango"),
+        _fake_device(104, "Sprite 8-zone", type_id="Sprite"),  # not Whisperer
+    ]
+    mock_indigo.devices.iter.return_value = iter(devs)
+    from plugin import Plugin  # noqa: WPS433
+    plugin = Plugin.__new__(Plugin)
+    result = plugin.getWhispererDevices()
+    assert result[0] == ("", "(Unpaired — use Netro forecast)")
+    assert result[1:] == [("102", "apple"), ("103", "Mango"), ("101", "Zebra")]
+
+
+def test_ignores_non_whisperer_devices(mock_indigo):
+    """Sprite/Pixie/Spark controllers and zones are excluded."""
+    devs = [
+        _fake_device(1, "Sprite 8", type_id="Sprite"),
+        _fake_device(2, "Pixie 12", type_id="Pixie"),
+        _fake_device(3, "Zone A", type_id="zone"),
+        _fake_device(4, "Garden Whisperer", type_id="Whisperer"),
+    ]
+    mock_indigo.devices.iter.return_value = iter(devs)
+    from plugin import Plugin  # noqa: WPS433
+    plugin = Plugin.__new__(Plugin)
+    result = plugin.getWhispererDevices()
+    whisperer_ids = [r[0] for r in result[1:]]
+    assert whisperer_ids == ["4"]

--- a/tests/test_whisperer_pairing_callback.py
+++ b/tests/test_whisperer_pairing_callback.py
@@ -1,31 +1,15 @@
 """Tests for Plugin.getWhispererDevices ConfigUI callback."""
-import sys
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 
 @pytest.fixture
-def mock_indigo(monkeypatch):
-    """Install a minimal `indigo` module into sys.modules for plugin import.
-
-    `PluginBase` must be a real class so `class Plugin(indigo.PluginBase):`
-    at import time produces a real class — not a MagicMock attribute.
-    """
-    indigo = MagicMock()
-
-    class _PluginBase:
-        pass
-
-    indigo.PluginBase = _PluginBase
-    indigo.Dict = dict
-    indigo.devices.iter = MagicMock(return_value=iter([]))
-    monkeypatch.setitem(sys.modules, "indigo", indigo)
-    # Force a fresh import of `plugin` so the Plugin class is rebuilt against
-    # this fixture's mock (previous tests may have cached a stale module).
-    monkeypatch.delitem(sys.modules, "plugin", raising=False)
-    return indigo
+def mock_indigo(mock_indigo_base):
+    """Extend conftest mock_indigo_base with iter() for callback tests."""
+    mock_indigo_base.devices.iter = MagicMock(return_value=iter([]))
+    return mock_indigo_base
 
 
 def _fake_device(dev_id, name, type_id="Whisperer"):

--- a/tests/test_zone_handler.py
+++ b/tests/test_zone_handler.py
@@ -221,11 +221,11 @@ class TestProcessZoneMoisture:
         states = zone_handler.process_zone_moisture(
             sample_moistures_response, zone_number=99
         )
-        state_dict = {s["key"]: s["value"] for s in states}
-        assert state_dict["moisture"] == 0
+        # Empty list signals "no data for this zone" — caller skips writing.
+        assert states == []
 
     def test_empty_moistures(self, zone_handler):
         response = {"data": {"moistures": []}}
         states = zone_handler.process_zone_moisture(response, zone_number=1)
-        state_dict = {s["key"]: s["value"] for s in states}
-        assert state_dict["moisture"] == 0
+        # Empty list signals "no data" — caller skips moistureForecast write.
+        assert states == []

--- a/tests/test_zone_moisture_resolution.py
+++ b/tests/test_zone_moisture_resolution.py
@@ -1,0 +1,158 @@
+"""Tests for Plugin._resolve_zone_moisture."""
+import sys
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _PluginBase:
+    """Stand-in for indigo.PluginBase used at Plugin class definition time."""
+
+
+@pytest.fixture
+def mock_indigo(monkeypatch):
+    """Install a minimal `indigo` module into sys.modules for plugin import.
+
+    `PluginBase` must be a real class so `class Plugin(indigo.PluginBase):`
+    at import time produces a real class — not a MagicMock attribute.
+    """
+    indigo = MagicMock()
+    indigo.PluginBase = _PluginBase
+    indigo.Dict = dict
+    indigo._devices_by_id = {}
+
+    def _getitem(dev_id):
+        if dev_id not in indigo._devices_by_id:
+            raise KeyError(dev_id)
+        return indigo._devices_by_id[dev_id]
+
+    indigo.devices.__getitem__.side_effect = _getitem
+    monkeypatch.setitem(sys.modules, "indigo", indigo)
+    # Force a fresh import of `plugin` so the Plugin class is rebuilt against
+    # this fixture's mock (previous tests may have cached a stale module).
+    monkeypatch.delitem(sys.modules, "plugin", raising=False)
+    return indigo
+
+
+@pytest.fixture
+def plugin_instance(mock_indigo):
+    from plugin import Plugin  # noqa: WPS433
+    return Plugin.__new__(Plugin)
+
+
+def _fake_whisperer(enabled=True, soil=30, reading_time="2026-04-23T10:00:00"):
+    return SimpleNamespace(
+        enabled=enabled,
+        states={"soilMoisture": soil, "readingTime": reading_time},
+    )
+
+
+def _fake_zone(linked_id=""):
+    return SimpleNamespace(pluginProps={"linkedWhispererDeviceId": linked_id})
+
+
+FROZEN_NOW = datetime(2026, 4, 23, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# --- Unpaired paths ---
+
+def test_unpaired_returns_forecast(plugin_instance):
+    zone = _fake_zone(linked_id="")
+    val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=55)
+    assert (val, src) == (55, "forecast")
+
+
+def test_unpaired_forecast_none(plugin_instance):
+    zone = _fake_zone(linked_id="")
+    val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=None)
+    assert (val, src) == (None, "forecast")
+
+
+# --- Paired, fresh ---
+
+def test_paired_fresh_returns_whisperer(plugin_instance, mock_indigo):
+    whisperer = _fake_whisperer(
+        soil=24,
+        reading_time=(FROZEN_NOW - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S"),
+    )
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (24, "whisperer")
+
+
+# --- Paired, stale ---
+
+def test_paired_stale_returns_forecast(plugin_instance, mock_indigo):
+    whisperer = _fake_whisperer(
+        soil=24,
+        reading_time=(FROZEN_NOW - timedelta(hours=20)).strftime("%Y-%m-%dT%H:%M:%S"),
+    )
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-stale")
+
+
+def test_paired_stale_forecast_also_none(plugin_instance, mock_indigo):
+    whisperer = _fake_whisperer(
+        soil=24,
+        reading_time=(FROZEN_NOW - timedelta(hours=20)).strftime("%Y-%m-%dT%H:%M:%S"),
+    )
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=None)
+    assert (val, src) == (None, "forecast-stale")
+
+
+# --- Paired, Whisperer missing ---
+
+def test_paired_device_deleted(plugin_instance, mock_indigo):
+    zone = _fake_zone(linked_id="999")  # 999 not in _devices_by_id
+    val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-missing-device")
+
+
+def test_paired_invalid_id(plugin_instance):
+    zone = _fake_zone(linked_id="not-an-int")
+    val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-missing-device")
+
+
+# --- Paired, Whisperer disabled ---
+
+def test_paired_device_disabled(plugin_instance, mock_indigo):
+    whisperer = _fake_whisperer(enabled=False, soil=24)
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-disabled-device")
+
+
+# --- Paired, unparseable time ---
+
+def test_paired_unparseable_reading_time(plugin_instance, mock_indigo):
+    whisperer = _fake_whisperer(reading_time="unknown")
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-stale")
+
+
+# --- Paired, no soilMoisture state ---
+
+def test_paired_no_soil_state(plugin_instance, mock_indigo):
+    whisperer = SimpleNamespace(
+        enabled=True,
+        states={"readingTime": "2026-04-23T10:00:00"},  # soilMoisture missing
+    )
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-stale")

--- a/tests/test_zone_moisture_resolution.py
+++ b/tests/test_zone_moisture_resolution.py
@@ -1,5 +1,4 @@
 """Tests for Plugin._resolve_zone_moisture."""
-import sys
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -7,20 +6,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-class _PluginBase:
-    """Stand-in for indigo.PluginBase used at Plugin class definition time."""
-
-
 @pytest.fixture
-def mock_indigo(monkeypatch):
-    """Install a minimal `indigo` module into sys.modules for plugin import.
-
-    `PluginBase` must be a real class so `class Plugin(indigo.PluginBase):`
-    at import time produces a real class — not a MagicMock attribute.
-    """
-    indigo = MagicMock()
-    indigo.PluginBase = _PluginBase
-    indigo.Dict = dict
+def mock_indigo(mock_indigo_base):
+    """Extend the shared mock_indigo_base with a `_devices_by_id` lookup."""
+    indigo = mock_indigo_base
     indigo._devices_by_id = {}
 
     def _getitem(dev_id):
@@ -29,10 +18,6 @@ def mock_indigo(monkeypatch):
         return indigo._devices_by_id[dev_id]
 
     indigo.devices.__getitem__.side_effect = _getitem
-    monkeypatch.setitem(sys.modules, "indigo", indigo)
-    # Force a fresh import of `plugin` so the Plugin class is rebuilt against
-    # this fixture's mock (previous tests may have cached a stale module).
-    monkeypatch.delitem(sys.modules, "plugin", raising=False)
     return indigo
 
 
@@ -223,3 +208,22 @@ def test_paired_soil_integer_zero_with_valid_reading(plugin_instance, mock_indig
     with patch("utils._now_utc", return_value=FROZEN_NOW):
         val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
     assert (val, src) == (0, "whisperer")
+
+
+# --- Boundary: WHISPERER_STALENESS_HOURS is strict > (not >=) ---
+
+@pytest.mark.parametrize("hours_old,expected_source", [
+    (11.9, "whisperer"),
+    (12.0, "whisperer"),  # boundary is > not >=
+    (12.1, "forecast-stale"),
+])
+def test_staleness_threshold_boundary(plugin_instance, mock_indigo, hours_old, expected_source):
+    whisperer = _fake_whisperer(
+        soil=24,
+        reading_time=(FROZEN_NOW - timedelta(hours=hours_old)).strftime("%Y-%m-%dT%H:%M:%S"),
+    )
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        _, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert src == expected_source

--- a/tests/test_zone_moisture_resolution.py
+++ b/tests/test_zone_moisture_resolution.py
@@ -184,12 +184,20 @@ def test_paired_non_numeric_soil_treated_as_invalid_reading(plugin_instance, moc
     assert (val, src) == (89, "forecast-invalid-reading")
 
 
-# --- Paired, readingID == 0 (sensor uninitialised) ---
+# --- Paired, readingID == 0 or absent (sensor uninitialised / state missing) ---
 
-def test_paired_reading_id_zero_is_missing_reading(plugin_instance, mock_indigo):
-    """readingID == 0 (Indigo Integer-state default) → sensor hasn't reported yet."""
-    fresh = (FROZEN_NOW - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
-    whisperer = _fake_whisperer(soil=24, reading_time=fresh, reading_id=0)
+@pytest.mark.parametrize("reading_id_value", [0, None])
+def test_paired_reading_id_zero_or_missing_is_missing_reading(
+    plugin_instance, mock_indigo, reading_id_value
+):
+    """readingID == 0 OR readingID None (key missing) both → forecast-missing-reading."""
+    states = {
+        "soilMoisture": 24,
+        "readingTime": (FROZEN_NOW - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S"),
+    }
+    if reading_id_value is not None:
+        states["readingID"] = reading_id_value
+    whisperer = SimpleNamespace(enabled=True, states=states)
     mock_indigo._devices_by_id[999] = whisperer
     zone = _fake_zone(linked_id="999")
     with patch("utils._now_utc", return_value=FROZEN_NOW):

--- a/tests/test_zone_moisture_resolution.py
+++ b/tests/test_zone_moisture_resolution.py
@@ -167,7 +167,7 @@ def test_paired_fresh_v1_epoch_millis(plugin_instance, mock_indigo):
 
 # --- Paired, non-numeric soilMoisture (defensive) ---
 
-def test_paired_non_numeric_soil_treated_as_missing_reading(plugin_instance, mock_indigo):
+def test_paired_non_numeric_soil_treated_as_invalid_reading(plugin_instance, mock_indigo):
     """Non-numeric soilMoisture (should never happen in practice) falls back safely."""
     whisperer = SimpleNamespace(
         enabled=True,
@@ -181,7 +181,7 @@ def test_paired_non_numeric_soil_treated_as_missing_reading(plugin_instance, moc
     zone = _fake_zone(linked_id="999")
     with patch("utils._now_utc", return_value=FROZEN_NOW):
         val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
-    assert (val, src) == (89, "forecast-missing-reading")
+    assert (val, src) == (89, "forecast-invalid-reading")
 
 
 # --- Paired, readingID == 0 (sensor uninitialised) ---

--- a/tests/test_zone_moisture_resolution.py
+++ b/tests/test_zone_moisture_resolution.py
@@ -156,3 +156,31 @@ def test_paired_no_soil_state(plugin_instance, mock_indigo):
     with patch("utils._now_utc", return_value=FROZEN_NOW):
         val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
     assert (val, src) == (89, "forecast-stale")
+
+
+# --- Paired, v1 epoch-millis readingTime ---
+
+def test_paired_fresh_v1_epoch_millis(plugin_instance, mock_indigo):
+    """v1 API stores readingTime as an epoch-millis int — resolver should honour it."""
+    two_hours_ago_ms = int((FROZEN_NOW - timedelta(hours=2)).timestamp() * 1000)
+    whisperer = _fake_whisperer(soil=28, reading_time=two_hours_ago_ms)
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (28, "whisperer")
+
+
+# --- Paired, non-numeric soilMoisture (defensive) ---
+
+def test_paired_non_numeric_soil_treated_as_stale(plugin_instance, mock_indigo):
+    """Non-numeric soilMoisture (should never happen in practice) falls back safely."""
+    whisperer = SimpleNamespace(
+        enabled=True,
+        states={"soilMoisture": "unknown", "readingTime": "2026-04-23T10:00:00"},
+    )
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-stale")

--- a/tests/test_zone_moisture_resolution.py
+++ b/tests/test_zone_moisture_resolution.py
@@ -39,18 +39,27 @@ def mock_indigo(monkeypatch):
 @pytest.fixture
 def plugin_instance(mock_indigo):
     from plugin import Plugin  # noqa: WPS433
-    return Plugin.__new__(Plugin)
+    plugin = Plugin.__new__(Plugin)
+    plugin.logger = MagicMock()
+    return plugin
 
 
-def _fake_whisperer(enabled=True, soil=30, reading_time="2026-04-23T10:00:00"):
+def _fake_whisperer(enabled=True, soil=30, reading_time="2026-04-23T10:00:00", reading_id=1001):
     return SimpleNamespace(
         enabled=enabled,
-        states={"soilMoisture": soil, "readingTime": reading_time},
+        states={
+            "soilMoisture": soil,
+            "readingTime": reading_time,
+            "readingID": reading_id,
+        },
     )
 
 
-def _fake_zone(linked_id=""):
-    return SimpleNamespace(pluginProps={"linkedWhispererDeviceId": linked_id})
+def _fake_zone(linked_id="", name="Test Zone"):
+    return SimpleNamespace(
+        name=name,
+        pluginProps={"linkedWhispererDeviceId": linked_id},
+    )
 
 
 FROZEN_NOW = datetime(2026, 4, 23, 12, 0, 0, tzinfo=timezone.utc)
@@ -141,7 +150,7 @@ def test_paired_unparseable_reading_time(plugin_instance, mock_indigo):
     mock_indigo._devices_by_id[999] = whisperer
     zone = _fake_zone(linked_id="999")
     val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
-    assert (val, src) == (89, "forecast-stale")
+    assert (val, src) == (89, "forecast-unparseable-time")
 
 
 # --- Paired, no soilMoisture state ---
@@ -149,13 +158,13 @@ def test_paired_unparseable_reading_time(plugin_instance, mock_indigo):
 def test_paired_no_soil_state(plugin_instance, mock_indigo):
     whisperer = SimpleNamespace(
         enabled=True,
-        states={"readingTime": "2026-04-23T10:00:00"},  # soilMoisture missing
+        states={"readingTime": "2026-04-23T10:00:00", "readingID": 1001},  # soilMoisture missing
     )
     mock_indigo._devices_by_id[999] = whisperer
     zone = _fake_zone(linked_id="999")
     with patch("utils._now_utc", return_value=FROZEN_NOW):
         val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
-    assert (val, src) == (89, "forecast-stale")
+    assert (val, src) == (89, "forecast-missing-reading")
 
 
 # --- Paired, v1 epoch-millis readingTime ---
@@ -173,14 +182,44 @@ def test_paired_fresh_v1_epoch_millis(plugin_instance, mock_indigo):
 
 # --- Paired, non-numeric soilMoisture (defensive) ---
 
-def test_paired_non_numeric_soil_treated_as_stale(plugin_instance, mock_indigo):
+def test_paired_non_numeric_soil_treated_as_missing_reading(plugin_instance, mock_indigo):
     """Non-numeric soilMoisture (should never happen in practice) falls back safely."""
     whisperer = SimpleNamespace(
         enabled=True,
-        states={"soilMoisture": "unknown", "readingTime": "2026-04-23T10:00:00"},
+        states={
+            "soilMoisture": "unknown",
+            "readingTime": "2026-04-23T10:00:00",
+            "readingID": 1001,
+        },
     )
     mock_indigo._devices_by_id[999] = whisperer
     zone = _fake_zone(linked_id="999")
     with patch("utils._now_utc", return_value=FROZEN_NOW):
         val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
-    assert (val, src) == (89, "forecast-stale")
+    assert (val, src) == (89, "forecast-missing-reading")
+
+
+# --- Paired, readingID == 0 (sensor uninitialised) ---
+
+def test_paired_reading_id_zero_is_missing_reading(plugin_instance, mock_indigo):
+    """readingID == 0 (Indigo Integer-state default) → sensor hasn't reported yet."""
+    fresh = (FROZEN_NOW - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
+    whisperer = _fake_whisperer(soil=24, reading_time=fresh, reading_id=0)
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (89, "forecast-missing-reading")
+
+
+# --- Paired, real soil=0 reading ---
+
+def test_paired_soil_integer_zero_with_valid_reading(plugin_instance, mock_indigo):
+    """soil=0 with readingID>0 and fresh time IS a valid sensor report (bone-dry)."""
+    fresh = (FROZEN_NOW - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
+    whisperer = _fake_whisperer(soil=0, reading_time=fresh, reading_id=1001)
+    mock_indigo._devices_by_id[999] = whisperer
+    zone = _fake_zone(linked_id="999")
+    with patch("utils._now_utc", return_value=FROZEN_NOW):
+        val, src = plugin_instance._resolve_zone_moisture(zone, forecast_val=89)
+    assert (val, src) == (0, "whisperer")


### PR DESCRIPTION
Closes #54.

## Summary

Adds per-zone Whisperer pairing in the plugin so the zone's `moisture`
state reflects the actual soil sensor reading (when fresh, ≤ 12h old)
rather than Netro's smart-model daily prediction. Netro's prediction
remains observable on a new `moistureForecast` state.

- **New pluginProp** `linkedWhispererDeviceId` on zone devices.
- **New ConfigUI dropdown** "Paired Whisperer" on the zone device
  config, populated by a dynamic `getWhispererDevices` callback.
- **New state** `moistureForecast` — always holds the raw
  `/moistures.json` prediction for the zone.
- **Zone `moisture` semantics** — resolves to the paired Whisperer's
  `soilMoisture` when fresh, else falls back to `moistureForecast`.
  Falls back cleanly when the pairing is missing, disabled, stale,
  unparseable, or has no reading yet — each case logged with a
  distinct message only on category transitions (no log spam).
- **No Netro API changes** — pairing is entirely plugin-side.

Design: `docs/plans/2026-04-23-whisperer-zone-pairing-design.md`
Implementation plan: `docs/plans/2026-04-23-whisperer-zone-pairing-plan.md`

## Build history

Implemented via TDD with 11 bite-sized commits, then hardened through
a multi-agent code review that caught (a) a production `pluginProps`
read-only bug found during live dogfooding on jarvis, (b) a latent
state-write-drop on auxiliary-log failure, (c) five distinct failure
modes collapsing into one misleading `forecast-stale` tag, and (d)
Indigo's integer-default `0` sneaking through as a "fresh" sensor
reading. All fixed on this branch; no follow-up PR needed.

## Test plan

- [x] `pytest tests/` — **488 passed** (up from 438 baseline, +50).
- [x] `pylint` on `plugin.py` / `utils.py` / `constants.py` /
      `device_handlers.py` — **9.48/10** (no regression).
- [x] Full plugin deployed to live Indigo server (jarvis) as
      2026.5.0 → hotfix → 2026.5.1. Currently running cleanly with
      zero errors since last restart.
- [x] New test modules cover every resolver source tag with
      `(value, source)` tuple assertions:
  - `tests/test_constants_whisperer.py`
  - `tests/test_reading_age.py` (v1 epoch millis + v2 ISO 8601,
    including Z suffix, garbage input, bool rejection, clock skew)
  - `tests/test_whisperer_pairing_callback.py`
  - `tests/test_zone_moisture_resolution.py` (unpaired, paired+fresh,
    stale, missing-device, disabled-device, missing-reading,
    unparseable-time, readingID liveness, 12h boundary)
  - `tests/test_moisture_source_logging.py` (all 5 transition
    messages, cold-start silence, replacePluginPropsOnServer failure
    graceful handling)
  - `tests/test_update_zone_devices_integration.py` (end-to-end
    paired/unpaired × fresh/stale matrix, empty-moistures fallback,
    logger-wiring verification)
- [ ] **Open empirical question** from design doc: verify
      `/moistures.json` keeps producing sane predictions when a
      Whisperer is paired in Netro but stops reporting. Recommended
      to dogfood with a disconnected Whisperer for ~1 week before
      fully relying on the fallback.

## Breaking changes

None. Backward compatible:
- Existing zones have no `linkedWhispererDeviceId` prop → `""` →
  unpaired path → identical to pre-PR behaviour (`moisture` shows
  the Netro forecast, same as today).
- `moistureForecast` starts populating on next poll; no data
  backfill needed.
- `UiDisplayStateId` stays `moisture` — zone tiles in Indigo keep
  showing the "primary" value (now sensor-or-forecast) which is the
  right default.

## Files changed

```
 Netro Sprinklers.indigoPlugin/Contents/Info.plist      |    2 +-
 .../Contents/Server Plugin/Devices.xml                 |   28 +
 .../Contents/Server Plugin/constants.py                |    9 +
 .../Contents/Server Plugin/device_handlers.py          |    6 +-
 .../Contents/Server Plugin/plugin.py                   |  199 ++-
 .../Contents/Server Plugin/utils.py                    |   76 +-
 README.md                                              |   13 +
 docs/API_NOTES.md                                      |  443 +++++++
 docs/plans/...                                         | 1688 +++++++++++++++
 tests/ (6 new + 2 modified)                            |  820 +++++++++
```

Version: `2026.4.4` → `2026.5.1` (minor for the user-visible feature
+ patch for review-hardening fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zone-to-Whisperer sensor pairing for per-zone soil moisture with a UI option to select a Whisperer device.
  * New separate moistureForecast state exposing Netro forecast while moisture reflects the best available value.

* **Bug Fixes**
  * Avoids writing spurious 0% moisture when no valid data is available; resolves stale/missing data handling.

* **Documentation**
  * README pairing instructions and expanded API notes.

* **Tests**
  * Added unit and integration tests covering parsing, resolution, logging, and the pairing callback.

* **Chores**
  * Plugin version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->