### PR TITLE
ci: replace workflows with canonical templates

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,23 +17,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine plugin name
-        id: get_plugin_name
+      - name: Determine plugin bundle
+        id: get_plugin
         run: |
-          PLUGIN_BUNDLE=$(find . -maxdepth 1 -iname "*.indigoPlugin" -type d | head -1)
-          if [ -z "$PLUGIN_BUNDLE" ]; then
+          PLUGIN_BUNDLE_PATH=$(find . -maxdepth 1 -iname "*.indigoPlugin" -type d | head -1)
+          if [ -z "$PLUGIN_BUNDLE_PATH" ]; then
             echo "Error: No .indigoPlugin directory found in repository root." >&2
             exit 1
           fi
-          PLUGIN_NAME=$(basename "$PLUGIN_BUNDLE" .indigoPlugin)
-          echo "plugin_name=$PLUGIN_NAME" >> $GITHUB_OUTPUT
-          echo "Detected plugin name: $PLUGIN_NAME"
+          PLUGIN_BUNDLE=$(basename "$PLUGIN_BUNDLE_PATH")
+          echo "plugin_bundle=$PLUGIN_BUNDLE" >> $GITHUB_OUTPUT
+          echo "Detected plugin bundle: $PLUGIN_BUNDLE"
 
       - name: Extract version from Info.plist
         id: get_version
         run: |
-          PLUGIN_NAME="${{ steps.get_plugin_name.outputs.plugin_name }}"
-          VERSION=$(grep -A1 '<key>PluginVersion</key>' "${PLUGIN_NAME}.indigoPlugin/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          PLUGIN_BUNDLE="${{ steps.get_plugin.outputs.plugin_bundle }}"
+          VERSION=$(grep -A1 '<key>PluginVersion</key>' "${PLUGIN_BUNDLE}/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
           if [ -z "$VERSION" ]; then
             echo "Error: Could not extract PluginVersion from Info.plist." >&2
             exit 1
@@ -56,8 +56,8 @@ jobs:
       - name: Create plugin bundle zip
         if: steps.check_release.outputs.exists == 'false'
         run: |
-          PLUGIN_NAME="${{ steps.get_plugin_name.outputs.plugin_name }}"
-          zip -r "${PLUGIN_NAME}.indigoPlugin.zip" "${PLUGIN_NAME}.indigoPlugin" \
+          PLUGIN_BUNDLE="${{ steps.get_plugin.outputs.plugin_bundle }}"
+          zip -r "${PLUGIN_BUNDLE}.zip" "${PLUGIN_BUNDLE}" \
             -x "*.pyc" \
             -x "*/__pycache__" \
             -x "*/__pycache__/*" \
@@ -67,7 +67,7 @@ jobs:
             -x "*/.idea/*" \
             -x "*.bbproject" \
             -x "*.bbproject/*"
-          echo "Created ${PLUGIN_NAME}.indigoPlugin.zip"
+          echo "Created ${PLUGIN_BUNDLE}.zip"
 
       - name: Create GitHub Release
         if: steps.check_release.outputs.exists == 'false'
@@ -78,4 +78,4 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: false
-          files: ${{ steps.get_plugin_name.outputs.plugin_name }}.indigoPlugin.zip
+          files: ${{ steps.get_plugin.outputs.plugin_bundle }}.zip

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Determine plugin name
         id: get_plugin_name
         run: |
-          PLUGIN_BUNDLE=$(find . -maxdepth 1 -name "*.indigoPlugin" -type d | head -1)
+          PLUGIN_BUNDLE=$(find . -maxdepth 1 -iname "*.indigoPlugin" -type d | head -1)
           if [ -z "$PLUGIN_BUNDLE" ]; then
             echo "Error: No .indigoPlugin directory found in repository root." >&2
             exit 1

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -2,7 +2,9 @@ name: Create Release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - master
 
 jobs:
   create-release:
@@ -10,44 +12,70 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Determine plugin name
+        id: get_plugin_name
+        run: |
+          PLUGIN_BUNDLE=$(find . -maxdepth 1 -name "*.indigoPlugin" -type d | head -1)
+          if [ -z "$PLUGIN_BUNDLE" ]; then
+            echo "Error: No .indigoPlugin directory found in repository root." >&2
+            exit 1
+          fi
+          PLUGIN_NAME=$(basename "$PLUGIN_BUNDLE" .indigoPlugin)
+          echo "plugin_name=$PLUGIN_NAME" >> $GITHUB_OUTPUT
+          echo "Detected plugin name: $PLUGIN_NAME"
+
       - name: Extract version from Info.plist
         id: get_version
         run: |
-          VERSION=$(grep -A1 '<key>PluginVersion</key>' "Netro Sprinklers.indigoPlugin/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          PLUGIN_NAME="${{ steps.get_plugin_name.outputs.plugin_name }}"
+          VERSION=$(grep -A1 '<key>PluginVersion</key>' "${PLUGIN_NAME}.indigoPlugin/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "Error: Could not extract PluginVersion from Info.plist." >&2
+            exit 1
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Found version: $VERSION"
+          echo "Extracted version: $VERSION"
 
-      - name: Check if tag already exists
-        id: check_tag
+      - name: Check if release already exists
+        id: check_release
         run: |
           VERSION="${{ steps.get_version.outputs.version }}"
-          if git tag -l | grep -q "^${VERSION}$"; then
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Tag ${VERSION} already exists, skipping release creation"
+            echo "Release v$VERSION already exists, skipping."
           else
             echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Tag ${VERSION} does not exist, will create release"
+            echo "Release v$VERSION does not exist, will create."
           fi
 
       - name: Create plugin bundle zip
-        if: steps.check_tag.outputs.exists == 'false'
+        if: steps.check_release.outputs.exists == 'false'
         run: |
-          VERSION="${{ steps.get_version.outputs.version }}"
-          zip -r "Netro Sprinklers.indigoPlugin.zip" "Netro Sprinklers.indigoPlugin"
-          echo "Created Netro Sprinklers.indigoPlugin.zip"
+          PLUGIN_NAME="${{ steps.get_plugin_name.outputs.plugin_name }}"
+          zip -r "${PLUGIN_NAME}.indigoPlugin.zip" "${PLUGIN_NAME}.indigoPlugin" \
+            -x "*.pyc" \
+            -x "*/__pycache__" \
+            -x "*/__pycache__/*" \
+            -x "*.sublime-project" \
+            -x "*.sublime-workspace" \
+            -x "*/.idea" \
+            -x "*/.idea/*" \
+            -x "*.bbproject" \
+            -x "*.bbproject/*"
+          echo "Created ${PLUGIN_NAME}.indigoPlugin.zip"
 
-      - name: Create Release
-        if: steps.check_tag.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v1
+      - name: Create GitHub Release
+        if: steps.check_release.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.get_version.outputs.version }}
-          name: Release ${{ steps.get_version.outputs.version }}
+          tag_name: v${{ steps.get_version.outputs.version }}
+          name: Release v${{ steps.get_version.outputs.version }}
           generate_release_notes: true
-          files: Netro Sprinklers.indigoPlugin.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          prerelease: false
+          files: ${{ steps.get_plugin_name.outputs.plugin_name }}.indigoPlugin.zip

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -15,23 +15,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine plugin name
-        id: get_plugin_name
+      - name: Determine plugin bundle
+        id: get_plugin
         run: |
-          PLUGIN_BUNDLE=$(find . -maxdepth 1 -iname "*.indigoPlugin" -type d | head -1)
-          if [ -z "$PLUGIN_BUNDLE" ]; then
+          PLUGIN_BUNDLE_PATH=$(find . -maxdepth 1 -iname "*.indigoPlugin" -type d | head -1)
+          if [ -z "$PLUGIN_BUNDLE_PATH" ]; then
             echo "Error: No .indigoPlugin directory found in repository root." >&2
             exit 1
           fi
-          PLUGIN_NAME=$(basename "$PLUGIN_BUNDLE" .indigoPlugin)
-          echo "plugin_name=$PLUGIN_NAME" >> $GITHUB_OUTPUT
-          echo "Detected plugin name: $PLUGIN_NAME"
+          PLUGIN_BUNDLE=$(basename "$PLUGIN_BUNDLE_PATH")
+          echo "plugin_bundle=$PLUGIN_BUNDLE" >> $GITHUB_OUTPUT
+          echo "Detected plugin bundle: $PLUGIN_BUNDLE"
 
       - name: Extract version from Info.plist
         id: get_version
         run: |
-          PLUGIN_NAME="${{ steps.get_plugin_name.outputs.plugin_name }}"
-          VERSION=$(grep -A1 '<key>PluginVersion</key>' "${PLUGIN_NAME}.indigoPlugin/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          PLUGIN_BUNDLE="${{ steps.get_plugin.outputs.plugin_bundle }}"
+          VERSION=$(grep -A1 '<key>PluginVersion</key>' "${PLUGIN_BUNDLE}/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
           if [ -z "$VERSION" ]; then
             echo "Error: Could not extract PluginVersion from Info.plist." >&2
             exit 1

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Determine plugin name
         id: get_plugin_name
         run: |
-          PLUGIN_BUNDLE=$(find . -maxdepth 1 -name "*.indigoPlugin" -type d | head -1)
+          PLUGIN_BUNDLE=$(find . -maxdepth 1 -iname "*.indigoPlugin" -type d | head -1)
           if [ -z "$PLUGIN_BUNDLE" ]; then
             echo "Error: No .indigoPlugin directory found in repository root." >&2
             exit 1

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -2,29 +2,52 @@ name: Version Check
 
 on:
   pull_request:
-    branches: [master, main]
+    branches:
+      - main
+      - master
 
 jobs:
   check-version:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Determine plugin name
+        id: get_plugin_name
+        run: |
+          PLUGIN_BUNDLE=$(find . -maxdepth 1 -name "*.indigoPlugin" -type d | head -1)
+          if [ -z "$PLUGIN_BUNDLE" ]; then
+            echo "Error: No .indigoPlugin directory found in repository root." >&2
+            exit 1
+          fi
+          PLUGIN_NAME=$(basename "$PLUGIN_BUNDLE" .indigoPlugin)
+          echo "plugin_name=$PLUGIN_NAME" >> $GITHUB_OUTPUT
+          echo "Detected plugin name: $PLUGIN_NAME"
+
       - name: Extract version from Info.plist
         id: get_version
         run: |
-          VERSION=$(grep -A1 '<key>PluginVersion</key>' "Netro Sprinklers.indigoPlugin/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Found version: $VERSION"
-
-      - name: Check if version tag already exists
-        run: |
-          VERSION="${{ steps.get_version.outputs.version }}"
-          if git tag -l | grep -q "^${VERSION}$"; then
-            echo "::error::Version ${VERSION} already exists as a tag. Please update the version in Info.plist."
+          PLUGIN_NAME="${{ steps.get_plugin_name.outputs.plugin_name }}"
+          VERSION=$(grep -A1 '<key>PluginVersion</key>' "${PLUGIN_NAME}.indigoPlugin/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "Error: Could not extract PluginVersion from Info.plist." >&2
             exit 1
           fi
-          echo "Version ${VERSION} is unique - check passed"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Check if tag already exists
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "::error::Version v$VERSION already exists as a git tag. Please update the PluginVersion in Info.plist."
+            exit 1
+          fi
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "::error::Version $VERSION already exists as a git tag. Please update the PluginVersion in Info.plist."
+            exit 1
+          fi
+          echo "✓ Version $VERSION is new and can be released."

--- a/Netro Sprinklers.indigoPlugin/Contents/Info.plist
+++ b/Netro Sprinklers.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.5.3</string>
+	<string>2026.5.5</string>
 	<key>ServerApiVersion</key>
 	<string>3.6</string>
 	<key>IwsApiVersion</key>


### PR DESCRIPTION
## Summary
- Replace hardcoded `version-check.yml` + `create-release.yml` with the canonical templates from [`indigo-claude-plugin`](https://github.com/simons-plugins/indigo-claude-plugin/blob/main/docs/plugin-dev/workflows/).
- Auto-detects `Netro Sprinklers.indigoPlugin` via `find -name '*.indigoPlugin'`.
- Upgrades `softprops/action-gh-release` v1 → v2 (Node 16 deprecation).
- Tag check switched from `grep` to `git rev-parse` (exact match).
- Tags now `v`-prefixed per workspace convention.

## Why
Workspace-wide rollout. `tests.yml` (pytest) is independent and unchanged.

## Version
Bumps 2026.5.3 → 2026.5.5 (skips 5.4 — collides with open PR `feat/testingbase-pilot`).

## Test plan
- [ ] version-check job runs and passes
- [ ] `tests.yml` pytest CI still runs unchanged
- [ ] After merge: `create-release` produces `v2026.5.5` tag + release with `Netro Sprinklers.indigoPlugin.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)